### PR TITLE
v1.1.0

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,6 @@
+## PR checklist
+
+ - [ ] This comment contains a description of changes (with reason).
+ - [ ] Bump version number within `prepare_eager_tsv.R`.
+ - [ ] `CHANGELOG.md` is updated.
+ - [ ] `README.md` is updated (including new tool citations and authors/contributors).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
-- Added bed file for on-target coverage calculation.
+- Added bed file for on-target coverage calculation for TF data. In SG this parameter gets overwritten and hence ignored.
 - `prepare_eager_tsv.R` now also creates a version file within the directory of the TSV.
 - Added github PR template.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Added`
 
 - Added bed file for on-target coverage calculation.
+- `prepare_eager_tsv.R` now also creates a version file within the directory of the TSV.
 
 ### `Fixed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [dev] - 
+
+### `Added`
+
+### `Fixed`
+
+- Parameters that require local paths have been moved to their own profile to aid in reproducibility outside of the EVA cluster.
+
+### `Dependencies`
+
+### `Deprecated`
+
 ## [1.0.0] - 19/09/2022
 
 ### `Added`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
+- Added bed file for on-target coverage calculation.
+
 ### `Fixed`
 
 - Parameters that require local paths have been moved to their own profile to aid in reproducibility outside of the EVA cluster.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added bed file for on-target coverage calculation.
 - `prepare_eager_tsv.R` now also creates a version file within the directory of the TSV.
+- Added github PR template.
 
 ### `Fixed`
 

--- a/README.md
+++ b/README.md
@@ -88,12 +88,14 @@ eager_inputs
          └── IND002
 ```
 
+Alongside each created TSV is a file named `autorun_eager_version.txt`, which states the version of Autorun_eager used.
+
 ## run_Eager.sh
 
 A wrapper shell script that goes through all TSVs in the `eager_inputs` directory, checks if a completed run exists for a given TSV, and submits/resumes an
 eager run for that individual if necessary.
 
-Currently uses eager version `2.4.5` and profiles `eva,archgen,medium_data,autorun` across all runs, with the `SG` or `TF` profiles used for their respective
+Currently uses eager version `2.4.5` and profiles `eva,archgen,medium_data,autorun,local_paths` across all runs, with the `SG` or `TF` profiles used for their respective
 data types.
 
 The outputs are saved with the same directory structure as the inputs, but in a separate parent directory.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ Broader scope options and parameters for use across all processing with autorun.
 
 Turns off automatic cleanup of intermediate files on successful completion of a run to allow resuming of the run when additional data becomes available, without rerunning completed steps.
 
+### local_paths
+
+This is profile contains all paramters provided to BOTH SG and TF runs that are paths to files on the local MPI-EVA filesystem. 
+They are provided in a separate profile to make it clearer to provided added transparency as well as make it easier for third parties to reproduce the processing done with Autorun_eager (e.g. by loading the `SG` or `TF` remote profiles) without getting errors about paths that do not exist on their filesystem.
+
 ### SG
 
 The standardised parameters for processing human shotgun data.

--- a/conf/Autorun.config
+++ b/conf/Autorun.config
@@ -26,6 +26,9 @@ profiles {
       bwa_index             = '/mnt/archgen/Reference_Genomes/Human/hs37d5/'
       seq_dict              = '/mnt/archgen/Reference_Genomes/Human/hs37d5/hs37d5.dict'
       
+      // Qualimap bedfile for on-target coverage calculation
+      snpcapture_bed        = '/mnt/archgen/Reference_Genomes/Human/hs37d5/SNPCapBEDs/1240K.pos.list_hs37d5.0based.bed'
+      
       // Genotyping
       pileupcaller_bedfile  = '/mnt/archgen/Reference_Genomes/Human/hs37d5/SNPCapBEDs/1240K.pos.list_hs37d5.0based.bed'
       pileupcaller_snpfile  = '/mnt/archgen/public_data/Datashare_Boston_Jena_June2018.backup/1240K.snp'

--- a/conf/Autorun.config
+++ b/conf/Autorun.config
@@ -15,16 +15,32 @@ profiles {
     }
   }
 
-  // Profile with parameters for runs using the Human_SG bams as input.
-  SG {
-   params{
+  // A profile with all the local paths to required files. 
+  // These will need to be provided manually by anyone wanting to reproduce the results outside of the EVA filesystem.
+  local_paths {
+    params {
       // Mapping reference and reference indexes
       // These are required by eager for Damage calculation etc. No mapping is taking place here.
-      fasta = '/mnt/archgen/Reference_Genomes/Human/hs37d5/hs37d5.fa'
-      fasta_index = '/mnt/archgen/Reference_Genomes/Human/hs37d5/hs37d5.fa.fai'
-      bwa_index = '/mnt/archgen/Reference_Genomes/Human/hs37d5/'
-      seq_dict = '/mnt/archgen/Reference_Genomes/Human/hs37d5/hs37d5.dict'
+      fasta                 = '/mnt/archgen/Reference_Genomes/Human/hs37d5/hs37d5.fa'
+      fasta_index           = '/mnt/archgen/Reference_Genomes/Human/hs37d5/hs37d5.fa.fai'
+      bwa_index             = '/mnt/archgen/Reference_Genomes/Human/hs37d5/'
+      seq_dict              = '/mnt/archgen/Reference_Genomes/Human/hs37d5/hs37d5.dict'
+      
+      // Genotyping
+      pileupcaller_bedfile  = '/mnt/archgen/Reference_Genomes/Human/hs37d5/SNPCapBEDs/1240K.pos.list_hs37d5.0based.bed'
+      pileupcaller_snpfile  = '/mnt/archgen/public_data/Datashare_Boston_Jena_June2018.backup/1240K.snp'
 
+      // Sex Det
+      sexdeterrmine_bedfile = '/mnt/archgen/Reference_Genomes/Human/hs37d5/SNPCapBEDs/1240K.pos.list_hs37d5.0based.bed'
+
+      // 1240k depth calculation
+      anno_file             = '/mnt/archgen/Reference_Genomes/Human/hs37d5/SNPCapBEDs/1240K.pos.list_hs37d5.0based.bed'
+
+    }
+  }
+  // Profile with parameters for runs using the Human_SG bams as input.
+  SG {
+    params{
       // BAM filtering
       run_bam_filtering = true           // Filter out unmapped reads, so barplots in MultiQC are not completely overtaken by unmapped reads.
       bam_mapping_quality_threshold = 0   // Keep all mapped reads 
@@ -53,14 +69,11 @@ profiles {
       genotyping_source = 'trimmed'           // Use trimmed bams for genotyping
       run_genotyping = true
       genotyping_tool = 'pileupcaller'
-      pileupcaller_bedfile = '/mnt/archgen/Reference_Genomes/Human/hs37d5/SNPCapBEDs/1240K.pos.list_hs37d5.0based.bed'
-      pileupcaller_snpfile = '/mnt/archgen/public_data/Datashare_Boston_Jena_June2018.backup/1240K.snp'
       pileupcaller_min_map_quality = 25       // To allow for reads aligning with a mismatch, and reduce reference bias in genotypes.
       pileupcaller_min_base_quality = 30
 
       //Sex determination
       run_sexdeterrmine = true
-      sexdeterrmine_bedfile = '/mnt/archgen/Reference_Genomes/Human/hs37d5/SNPCapBEDs/1240K.pos.list_hs37d5.0based.bed'
 
       // Nuclear contamination
       run_nuclear_contamination = true
@@ -68,7 +81,6 @@ profiles {
       
       //1240k Coverage/Depth calculation (for poseidonisation)
       run_bedtools_coverage = true
-      anno_file = '/mnt/archgen/Reference_Genomes/Human/hs37d5/SNPCapBEDs/1240K.pos.list_hs37d5.0based.bed'
     }
   }
 
@@ -76,14 +88,7 @@ profiles {
   // Profile with parameters for runs using the Human_1240k bams as input.
   // Currently identical to SG profile.
   TF {
- params{
-      // Mapping reference and reference indexes
-      // These are required by eager for Damage calculation etc. No mapping is taking place here.
-      fasta = '/mnt/archgen/Reference_Genomes/Human/hs37d5/hs37d5.fa'
-      fasta_index = '/mnt/archgen/Reference_Genomes/Human/hs37d5/hs37d5.fa.fai'
-      bwa_index = '/mnt/archgen/Reference_Genomes/Human/hs37d5/'
-      seq_dict = '/mnt/archgen/Reference_Genomes/Human/hs37d5/hs37d5.dict'
-
+    params{
       // BAM filtering
       run_bam_filtering = true           // Filter out unmapped reads, so barplots in MultiQC are not completely overtaken by unmapped reads.
       bam_mapping_quality_threshold = 0   // Keep all mapped reads 
@@ -112,14 +117,11 @@ profiles {
       genotyping_source = 'trimmed'           // Use trimmed bams for genotyping
       run_genotyping = true
       genotyping_tool = 'pileupcaller'
-      pileupcaller_bedfile = '/mnt/archgen/Reference_Genomes/Human/hs37d5/SNPCapBEDs/1240K.pos.list_hs37d5.0based.bed'
-      pileupcaller_snpfile = '/mnt/archgen/public_data/Datashare_Boston_Jena_June2018.backup/1240K.snp'
       pileupcaller_min_map_quality = 25       // To allow for reads aligning with a mismatch, and reduce reference bias in genotypes.
       pileupcaller_min_base_quality = 30
 
       //Sex determination
       run_sexdeterrmine = true
-      sexdeterrmine_bedfile = '/mnt/archgen/Reference_Genomes/Human/hs37d5/SNPCapBEDs/1240K.pos.list_hs37d5.0based.bed'
 
       // Nuclear contamination
       run_nuclear_contamination = true
@@ -127,7 +129,6 @@ profiles {
             
       //1240k Coverage/Depth calculation (for poseidonisation)
       run_bedtools_coverage = true
-      anno_file = '/mnt/archgen/Reference_Genomes/Human/hs37d5/SNPCapBEDs/1240K.pos.list_hs37d5.0based.bed'
     }
   }
 }

--- a/conf/Autorun.config
+++ b/conf/Autorun.config
@@ -54,6 +54,9 @@ profiles {
       run_mtnucratio = true
       mtnucratio_header = "MT"
       
+      // Ignore SNP capture bed for coverage calculations in non TF data.
+      snpcapture_bed        = null
+      
       // Bam Trimming
       // ssDNA libraries are left untrimmed (pileupcaller deals with damage in those)
       // dsDNA half-udg are clipped 2bp on either side, while non-UDG are clipper 7bp 

--- a/scripts/prepare_eager_tsv.R
+++ b/scripts/prepare_eager_tsv.R
@@ -39,6 +39,10 @@ save_ind_tsv <- function(data, rename, output_dir, ...) {
   }
   
   ind_dir <- paste0(output_dir, "/", site_id, "/", ind_id)
+
+  ## Print Autorun_eager version to file
+  AE_version <- "1.1.0"
+  cat(AE_version, file=paste0(ind_dir,"/autorun_eager_version.txt"), fill=T, append = F)
   
   if (!dir.exists(ind_dir)) {write(paste0("[prepare_eager_tsv.R]: Creating output directory '",ind_dir,"'"), stdout())}
   

--- a/scripts/run_Eager.sh
+++ b/scripts/run_Eager.sh
@@ -19,7 +19,7 @@ root_output_dir='/mnt/archgen/Autorun_eager/eager_outputs'
 # root_output_dir='/mnt/archgen/Autorun_eager/dev/testing/eager_outputs'
 
 ## Set base profiles for EVA cluster.
-nextflow_profiles="eva,archgen,medium_data,autorun"
+nextflow_profiles="eva,archgen,medium_data,autorun,local_paths"
 
 ## Set colour and face for colour printing
 Red='\033[1;31m'$(tput bold) ## Red bold face


### PR DESCRIPTION
### `Added`

- Added bed file for on-target coverage calculation for TF data. In SG this parameter gets overwritten and hence ignored.
- `prepare_eager_tsv.R` now also creates a version file within the directory of the TSV.
- Added github PR template

### `Fixed`

- Parameters that require local paths have been moved to their own profile to aid in reproducibility outside of the EVA cluster.

### `Dependencies`

### `Deprecated`

## PR checklist

 - [x] This comment contains a description of changes (with reason).
 - [x] Bump version number within `prepare_eager_tsv.R`.
 - [x] `CHANGELOG.md` is updated.
 - [x] `README.md` is updated (including new tool citations and authors/contributors).

Closes #11 
Closes #10 