### PR TITLE
1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `scripts/prepare_eager_tsv.R`: Add RP analysis type for twist capture results
   - `scripts/run_Eager.sh`: Run for RP TSVs.
   - `scripts/cron_daily_prepare.sh`: Create RP analysis TSVs daily.
+  - `scripts/ethical_sample_scrub.sh`: Add RP analysis type for ethical sample scrubbing.
+  - `scripts/clear_work_dirs.sh`: Add RP analysis type for work directory clearing.
+  - `scripts/clear_results.sh`: Add RP analysis type for results directory clearing.
 
 ### `Fixed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,37 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 12/07/2023
+
+### `Added`
+
+- Processing of RP data. (Twist capture)
+  - `conf/Autorun.config`: Add RP profile for processing twist capture results. Identical to TF for now.
+  - `scripts/prepare_eager_tsv.R`: Add RP analysis type for twist capture results
+  - `scripts/run_Eager.sh`: Run for RP TSVs.
+  - `scripts/cron_daily_prepare.sh`: Create RP analysis TSVs daily.
+
+### `Fixed`
+
+### `Dependencies`
+
+<!-- - nf-core/eager=2.5.0 -->
+
+### `Deprecated`
+
 ## [1.3.0] - 12/07/2023
 
 ### `Added`
- - `scripts/ethical_sample_scrub.sh`: A script to remove eager input/outputs for samples that were marked as ethically sensitive after the pipelines picked them up.
- - `scripts/cron_ethical_scrub.sh`: A cron-able script to run `ethical_sample_scrub.sh` daily.
- - `scripts/clear_work_dirs.sh`: A bash script to `rm -r` the work directories of an individual ID for both `SG` and `TF` processing.
- - `scripts/clear_results.sh`: A bash script that deletes the results for an individual while maintaining the nextflow process cache for them.
+
+- `scripts/ethical_sample_scrub.sh`: A script to remove eager input/outputs for samples that were marked as ethically sensitive after the pipelines picked them up.
+- `scripts/cron_ethical_scrub.sh`: A cron-able script to run `ethical_sample_scrub.sh` daily.
+- `scripts/clear_work_dirs.sh`: A bash script to `rm -r` the work directories of an individual ID for both `SG` and `TF` processing.
+- `scripts/clear_results.sh`: A bash script that deletes the results for an individual while maintaining the nextflow process cache for them.
 
 ### `Fixed`
- - `scripts/cron_daily_prepare.sh`: Silenced permission errors due to ethical sample scrubbing.
+
+- `scripts/cron_daily_prepare.sh`: Silenced permission errors due to ethical sample scrubbing.
+
 ### `Dependencies`
 
 ### `Deprecated`
@@ -20,11 +41,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.2.0] - 21/03/2023
 
 ### `Added`
- - `prepare_eager_tsv.R`: Added `-w/--whitelist` option. A whitelist of Pandora Individual IDs can be provided. Only the TSVs of individuals in the whitelist will be updated.
+
+- `prepare_eager_tsv.R`: Added `-w/--whitelist` option. A whitelist of Pandora Individual IDs can be provided. Only the TSVs of individuals in the whitelist will be updated.
 
 ### `Fixed`
- - `update_poseidon_packages.sh`: `Library_Names` field now includes only unique library names.
- - `prepare_eager_tsv.R`: Camel_Case versions of Pandora Analysis IDs are no longer filtered out.
+
+- `update_poseidon_packages.sh`: `Library_Names` field now includes only unique library names.
+- `prepare_eager_tsv.R`: Camel_Case versions of Pandora Analysis IDs are no longer filtered out.
 
 ### `Dependencies`
 
@@ -35,9 +58,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Added`
 
 ### `Fixed`
- - Column naming in `fill_in_janno.R`. `Nr_Libs` -> `Nr_Libraries`.
- - `prepare_eager_tsv.R` no longer joins with non-unique iids. Optimised performance and less likely to kill the TSV maker.
- - Increased memory given to eager spawner array jobs.
+
+- Column naming in `fill_in_janno.R`. `Nr_Libs` -> `Nr_Libraries`.
+- `prepare_eager_tsv.R` no longer joins with non-unique iids. Optimised performance and less likely to kill the TSV maker.
+- Increased memory given to eager spawner array jobs.
 
 ### `Dependencies`
 
@@ -46,6 +70,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.1.2] - 02/01/2023
 
 ### `Added`
+
 - Add `-a` option to `run_Eager.sh` to create a text file with the run commands for launching Autorun_eager, for submission as a qsub array.
 - Add array submission script.
 - Add script to create and update poseidon packages from eager output.
@@ -55,6 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added conda environment yaml file `autoeager_env.yml`
 
 ### `Fixed`
+
 - Fixed pull request template.
 - Fixed a bug where sequencing runs were considered updated if the `Results.txt` was updated without changing the data. Now only changes to the output bams constitute an update trigger.
 - Fixed a bug where TSV creation would try to match the sequencing ID to the sequencing batch ID, instead of the run ID.
@@ -70,6 +96,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Fixed`
 
 - An error was thrown when trying to create the version file in non existing directories. now fixed.
+
 ### `Dependencies`
 
 ### `Deprecated`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Processing of RP data. (Twist capture)
   - `conf/Autorun.config`: Add RP profile for processing twist capture results. Identical to TF for now.
+  - `conf/Autorun.config`: Use mapdamage for damage calculation. Limit to 100000 reads, to lower runtime.
   - `scripts/prepare_eager_tsv.R`: Add RP analysis type for twist capture results
   - `scripts/run_Eager.sh`: Run for RP TSVs.
   - `scripts/cron_daily_prepare.sh`: Create RP analysis TSVs daily.
@@ -17,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Dependencies`
 
-<!-- - nf-core/eager=2.5.0 -->
+- nf-core/eager=2.5.0
 
 ### `Deprecated`
 

--- a/conf/Autorun.config
+++ b/conf/Autorun.config
@@ -71,7 +71,11 @@ profiles {
       // Usually for dsDNA non-UDG libraries this is between 5 and 10. I have set it to 7 arbitrarily since that was a good cutoff in my own projects so far.
       bamutils_clip_double_stranded_none_udg_left = 7     // Trim 7 bp of either side for non-UDG libraries.
       bamutils_clip_double_stranded_none_udg_right = 7    // Trim 7 bp of either side for non-UDG libraries.
-      
+
+      // Damage Calculation
+      damage_calculation_tool = 'mapdamage'
+      mapdamage_downsample = 100000 // Use 100k reads for damage calculation to lower runtime.
+
       // Genotyping
       genotyping_source = 'trimmed'           // Use trimmed bams for genotyping
       run_genotyping = true
@@ -118,7 +122,11 @@ profiles {
       // Usually for dsDNA non-UDG libraries this is between 5 and 10. I have set it to 7 arbitrarily since that was a good cutoff in my own projects so far.
       bamutils_clip_double_stranded_none_udg_left = 7     // Trim 7 bp of either side for non-UDG libraries.
       bamutils_clip_double_stranded_none_udg_right = 7    // Trim 7 bp of either side for non-UDG libraries.
-      
+
+      // Damage Calculation
+      damage_calculation_tool = 'mapdamage'
+      mapdamage_downsample = 100000 // Use 100k reads for damage calculation to lower runtime.
+
       // Genotyping
       genotyping_source = 'trimmed'           // Use trimmed bams for genotyping
       run_genotyping = true
@@ -165,7 +173,11 @@ profiles {
       // Usually for dsDNA non-UDG libraries this is between 5 and 10. I have set it to 7 arbitrarily since that was a good cutoff in my own projects so far.
       bamutils_clip_double_stranded_none_udg_left = 7     // Trim 7 bp of either side for non-UDG libraries.
       bamutils_clip_double_stranded_none_udg_right = 7    // Trim 7 bp of either side for non-UDG libraries.
-      
+
+      // Damage Calculation
+      damage_calculation_tool = 'mapdamage'
+      mapdamage_downsample = 100000 // Use 100k reads for damage calculation to lower runtime.
+
       // Genotyping
       genotyping_source = 'trimmed'           // Use trimmed bams for genotyping
       run_genotyping = true

--- a/conf/Autorun.config
+++ b/conf/Autorun.config
@@ -91,10 +91,56 @@ profiles {
     }
   }
 
-
-  // Profile with parameters for runs using the Human_1240k bams as input.
-  // Currently identical to SG profile.
+  // Profile with parameters for runs using the Human_RP bams as input.
+  // Currently identical to SG profile, except it keeps the snpcapture_bed option.
   TF {
+    params{
+      // BAM filtering
+      run_bam_filtering = true           // Filter out unmapped reads, so barplots in MultiQC are not completely overtaken by unmapped reads.
+      bam_mapping_quality_threshold = 0   // Keep all mapped reads 
+      bam_unmapped_type = 'bam'          // Keep unmapped reads as a separate BAM file for possible future pathogen screening.
+      bam_filter_minreadlength = 30      // Do we need to add length filtering here at all? Does Kay's pre-processing do this?
+      
+      // mtDNA to nuclear ratio
+      run_mtnucratio = true
+      mtnucratio_header = "MT"
+      
+      // Bam Trimming
+      // ssDNA libraries are left untrimmed (pileupcaller deals with damage in those)
+      // dsDNA half-udg are clipped 2bp on either side, while non-UDG are clipper 7bp 
+      run_trim_bam = true
+      bamutils_clip_single_stranded_half_udg_left = 0     // Set to 0 so ssDNA do not get trimmed.
+      bamutils_clip_single_stranded_half_udg_right = 0    // Set to 0 so ssDNA do not get trimmed.
+      bamutils_clip_single_stranded_none_udg_left = 0     // Set to 0 so ssDNA do not get trimmed.
+      bamutils_clip_single_stranded_none_udg_right = 0    // Set to 0 so ssDNA do not get trimmed.
+      bamutils_clip_double_stranded_half_udg_left = 2     // Trim 2 bp of either side for half-UDG libraries.
+      bamutils_clip_double_stranded_half_udg_right = 2    // Trim 2 bp of either side for half-UDG libraries.
+      // Usually for dsDNA non-UDG libraries this is between 5 and 10. I have set it to 7 arbitrarily since that was a good cutoff in my own projects so far.
+      bamutils_clip_double_stranded_none_udg_left = 7     // Trim 7 bp of either side for non-UDG libraries.
+      bamutils_clip_double_stranded_none_udg_right = 7    // Trim 7 bp of either side for non-UDG libraries.
+      
+      // Genotyping
+      genotyping_source = 'trimmed'           // Use trimmed bams for genotyping
+      run_genotyping = true
+      genotyping_tool = 'pileupcaller'
+      pileupcaller_min_map_quality = 25       // To allow for reads aligning with a mismatch, and reduce reference bias in genotypes.
+      pileupcaller_min_base_quality = 30
+
+      //Sex determination
+      run_sexdeterrmine = true
+
+      // Nuclear contamination
+      run_nuclear_contamination = true
+      contamination_chrom_name = 'X'
+            
+      //1240k Coverage/Depth calculation (for poseidonisation)
+      run_bedtools_coverage = true
+    }
+  }
+
+  // Profile with parameters for runs using the Human_RP bams as input.
+  // Currently identical to TF profile. Just keeps the RP data separate for comparison.
+  RP {
     params{
       // BAM filtering
       run_bam_filtering = true           // Filter out unmapped reads, so barplots in MultiQC are not completely overtaken by unmapped reads.

--- a/scripts/clear_results.sh
+++ b/scripts/clear_results.sh
@@ -65,8 +65,8 @@ fi
 if [[ ${analysis_type} == '' ]]; then
   errecho "No --analysis_type was provided.\n"
   Helptext
-elif [[ ${analysis_type} != "SG" && ${analysis_type} != "TF" ]]; then
-  errecho "analysis_type must be SG or TF. You provided: ${analysis_type}\n"
+elif [[ ${analysis_type} != "SG" && ${analysis_type} != "TF" && ${analysis_type} != "RP" ]]; then
+  errecho "analysis_type must be SG, TF, or RP. You provided: ${analysis_type}\n"
   Helptext
 fi
 

--- a/scripts/clear_work_dirs.sh
+++ b/scripts/clear_work_dirs.sh
@@ -42,7 +42,7 @@ input_iids=($(cat ${ind_id_list_fn}))
 for ind_id in ${input_iids[@]}; do
   site_id=${ind_id:0:3} ## Site id is the first three characters of the individual ID
   errecho -ne "Clearing work directories for ${ind_id}..."
-  for analysis_type in SG TF; do
+  for analysis_type in "SG" "TF" "RP"; do
     if [[ -d ${root_eager_dir}/${analysis_type}/${site_id}/${ind_id}/work ]]; then
       errecho -ne " ${analysis_type}..."
       # ls -d ${root_eager_dir}/${analysis_type}/${site_id}/${ind_id}/work

--- a/scripts/cron_daily_prepare.sh
+++ b/scripts/cron_daily_prepare.sh
@@ -19,3 +19,10 @@ find /mnt/archgen/Autorun/Results/Human_Shotgun/2* -name '*.bam' -mtime -1 2>/de
     echo "Processing SG data from run: ${RUN}"
     scripts/prepare_eager_tsv.R -s $RUN -a SG -o eager_inputs/ -d .eva_credentials
 done 
+
+# Twist
+# Note: this find only checks runs starting from 2020.  Silence stderr to avoid 'permission denied'.
+find /mnt/archgen/Autorun/Results/Human_RP/2* -name '*.bam' -mtime -1 2>/dev/null | cut -f 7 -d "/" | sort -u | while read RUN ; do
+    echo "Processing RP data from run: ${RUN}"
+    scripts/prepare_eager_tsv.R -s $RUN -a RP -o eager_inputs/ -d .eva_credentials
+done 

--- a/scripts/ethical_sample_scrub.sh
+++ b/scripts/ethical_sample_scrub.sh
@@ -63,7 +63,7 @@ else
 
   ## If the individuals were flagged as sensitive AFTER processing started, both the inputs and outputs should be made inaccessible.
   for raw_iid in ${scrub_me[@]}; do
-    for analysis_type in "SG" "TF"; do
+    for analysis_type in "SG" "TF" "RP"; do
       ## EAGER_INPUTS
       site_id="${raw_iid:0:3}"
       eager_input_tsv="${root_input_dir}/${analysis_type}/${site_id}/${raw_iid}/${raw_iid}.tsv"

--- a/scripts/prepare_eager_tsv.R
+++ b/scripts/prepare_eager_tsv.R
@@ -20,7 +20,7 @@ require(stringr)
 
 ## Validate analysis type option input
 validate_analysis_type <- function(option, opt_str, value, parser) {
-  valid_entries <- c("TF", "SG") ## TODO comment: should this be embedded within the function? You would want to maybe update this over time no? 
+  valid_entries <- c("TF", "SG", "RP") ## TODO comment: should this be embedded within the function? You would want to maybe update this over time no? 
   ifelse(value %in% valid_entries, return(value), stop(call.=F, "\n[prepare_eager_tsv.R] error: Invalid analysis type: '", value, 
                                                       "'\nAccepted values: ", paste(valid_entries,collapse=", "),"\n\n"))
 }
@@ -46,7 +46,7 @@ save_ind_tsv <- function(data, rename, output_dir, ...) {
   data %>% select(-individual.Full_Individual_Id) %>%  readr::write_tsv(file=paste0(ind_dir,"/",ind_id,".tsv")) ## Output structure can be changed here.
 
   ## Print Autorun_eager version to file
-  AE_version <- "1.3.0"
+  AE_version <- "1.4.0"
   cat(AE_version, file=paste0(ind_dir,"/autorun_eager_version.txt"), fill=T, append = F)
 }
 
@@ -54,8 +54,9 @@ save_ind_tsv <- function(data, rename, output_dir, ...) {
 ##    Only bams from the output autorun_name will be included in the output
 autorun_names_from_analysis_type <- function(analysis_type) {
   autorun_names <- case_when(
-    analysis_type == "TF" ~ c( "HUMAN_1240K", "Human_1240k" ), 
+    analysis_type == "TF" ~ c( "HUMAN_1240K", "Human_1240k" ),
     analysis_type == "SG" ~ c( "HUMAN_SHOTGUN", "Human_Shotgun" ),
+    analysis_type == "RP" ~ c( "HUMAN_RP", "Human_RP" ),
     ## Future analyses can be added here to pull those bams for eager processsing.
     TRUE ~ NA_character_
   )

--- a/scripts/run_Eager.sh
+++ b/scripts/run_Eager.sh
@@ -35,7 +35,7 @@ Yellow=$(tput sgr0)'\033[1;33m' ## Yellow normal face
 
 ## Since I'm running through all data every time, the runtime of the script will increase marginally over time. 
 ## Maybe create a list of eager inputs that are newer than the MQC reports and use that to loop over?
-for analysis_type in "SG" "TF"; do
+for analysis_type in "SG" "TF" "RP"; do
     # echo ${analysis_type}
     analysis_profiles="${nextflow_profiles},${analysis_type}"
     # echo "${root_input_dir}/${analysis_type}"

--- a/scripts/run_Eager.sh
+++ b/scripts/run_Eager.sh
@@ -16,7 +16,7 @@ elif [[ $1 == '-a' || $1 == "--array" ]]; then
 fi
 
 nxf_path="/home/srv_autoeager/conda/envs/autoeager/bin/"
-eager_version='2.4.5'
+eager_version='2.5.0'
 autorun_config='/mnt/archgen/Autorun_eager/conf/Autorun.config' ## Contains specific profiles with params for each analysis type.
 root_input_dir='/mnt/archgen/Autorun_eager/eager_inputs' ## Directory should include subdirectories for each analysis type (TF/SG) and sub-subdirectories for each individual.
 ####        E.g. /mnt/archgen/Autorun_eager/eager_inputs/SG/GUB001/GUB001.tsv

--- a/scripts/update_poseidon_package.sh
+++ b/scripts/update_poseidon_package.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-VERSION="1.3.0"
+VERSION="1.4.0"
 
 ## Colours for printing to terminal
 Yellow=$(tput sgr0)'\033[1;33m' ## Yellow normal face


### PR DESCRIPTION
Closes #20 

- [x] Add processing of twist capture data.
- [x] Bump eager to version 2.5.0
  - [x] Use mapDamage with a read limit instead of damageprofiler to avoid long runtimes on deeper sequenced individuals.

## CHANGELOG

### `Added`

- Processing of RP data. (Twist capture)
  - `conf/Autorun.config`: Add RP profile for processing twist capture results. Identical to TF for now.
  - `scripts/prepare_eager_tsv.R`: Add RP analysis type for twist capture results
  - `scripts/run_Eager.sh`: Run for RP TSVs.
  - `scripts/cron_daily_prepare.sh`: Create RP analysis TSVs daily.

### `Fixed`

### `Dependencies`

 - nf-core/eager=2.5.0

### `Deprecated`

## PR checklist

 - [x] This comment contains a description of changes (with reason).
 - [x] Bump version number within `prepare_eager_tsv.R`.
 - [x] Bump version number in `update_poseidon_package.sh`.
 - [x] `CHANGELOG.md` is updated.
 - [ ] `README.md` is updated (including new tool citations and authors/contributors).