### PR TITLE
1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.0] - XX/XX/XXXX
+
+### `Added`
+
+- `conf/Autorun.config`: Use hard links when publishing results, instead of copying files.
+- `scripts/create_poseidon_release.sh`: New script to create large releases of the entire TF processed data in Poseidon format.
+
+### `Fixed`
+
+### `Dependencies`
+
+### `Deprecated`
+
 ## [1.5.0] - 30/09/2024
 
 ### `Added`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `conf/Autorun.config`: Use hard links when publishing results, instead of copying files.
 - `scripts/create_poseidon_release.sh`: New script to create large releases of the entire TF processed data in Poseidon format.
+- `scripts/clear_results.sh`: Now uses pyPandoraHelper to infer Site_ID from Ind_ID.
+- `scripts/clear_work_dirs.sh`: Now uses pyPandoraHelper to infer Site_ID from Ind_ID.
+- `scripts/ethical_sample_scrub.sh`: Now uses pyPandoraHelper to infer Site_ID from Ind_ID.
+- `scripts/run_Eager.sh`: Now uses pyPandoraHelper to infer Site_ID from Ind_ID.
+- `scripts/update_poseidon_packages.sh`: Now uses pyPandoraHelper to infer Site_ID from Ind_ID.
 
 ### `Fixed`
 
 ### `Dependencies`
+
+- pyPandoraHelper=0.1.0
 
 ### `Deprecated`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Added`
 
 - Processing of YC data. (Y + mtDNA capture (YMCA))
-- `conf/Autorun.config`: Use hard links when publishing results, instead of copying files.
+- `conf/Autorun.config`: 
+  - Use hard links when publishing results, instead of copying files.
+  - Add YC profile for processing YMCA data.
+  - Add IM profile for processing Immunocapture data.
 - `scripts/create_poseidon_release.sh`: New script to create large releases of the entire TF processed data in Poseidon format.
 - Now compatible with Pandora Site IDs longer than 3 letters.
   - The following scripts can now infer Site_ID of varied lengths from the Ind_ID (pyPandoraHelper):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.6.0] - XX/XX/XXXX
+## [1.6.0] - 07/03/2025
 
 ### `Added`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `conf/Autorun.config`: Use hard links when publishing results, instead of copying files.
 - `scripts/create_poseidon_release.sh`: New script to create large releases of the entire TF processed data in Poseidon format.
-- The following scripts now use pyPandoraHelper to infer Site_ID from Ind_ID:
+- Now compatible with Pandora Site IDs longer than 3 letters.
+  - The following scripts can now infer Site_ID of varied lengths from the Ind_ID (pyPandoraHelper):
   - `scripts/clear_results.sh`
   - `scripts/clear_work_dirs.sh`
   - `scripts/ethical_sample_scrub.sh`
   - `scripts/run_Eager.sh`
   - `scripts/update_poseidon_packages.sh`
-- The following scripts now use rPandoraHelper to infer Site_ID from Ind_ID:
-  - `scripts/prepare_eager_tsv.R`
-  - `scripts/fill_in_janno.R`
-- Now compatible with Pandora Site IDs longer than 3 letters.
+  - The following scripts can now infer Site_ID of varied lengths from the Ind_ID (rPandoraHelper):
+    - `scripts/prepare_eager_tsv.R`
+    - `scripts/fill_in_janno.R`
 
 ### `Fixed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
+- Processing of YC data. (Y + mtDNA capture (YMCA))
 - `conf/Autorun.config`: Use hard links when publishing results, instead of copying files.
 - `scripts/create_poseidon_release.sh`: New script to create large releases of the entire TF processed data in Poseidon format.
 - Now compatible with Pandora Site IDs longer than 3 letters.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `conf/Autorun.config`: Use hard links when publishing results, instead of copying files.
 - `scripts/create_poseidon_release.sh`: New script to create large releases of the entire TF processed data in Poseidon format.
-- `scripts/clear_results.sh`: Now uses pyPandoraHelper to infer Site_ID from Ind_ID.
-- `scripts/clear_work_dirs.sh`: Now uses pyPandoraHelper to infer Site_ID from Ind_ID.
-- `scripts/ethical_sample_scrub.sh`: Now uses pyPandoraHelper to infer Site_ID from Ind_ID.
-- `scripts/run_Eager.sh`: Now uses pyPandoraHelper to infer Site_ID from Ind_ID.
-- `scripts/update_poseidon_packages.sh`: Now uses pyPandoraHelper to infer Site_ID from Ind_ID.
+- The following scripts now use pyPandoraHelper to infer Site_ID from Ind_ID:
+  - `scripts/clear_results.sh`
+  - `scripts/clear_work_dirs.sh`
+  - `scripts/ethical_sample_scrub.sh`
+  - `scripts/run_Eager.sh`
+  - `scripts/update_poseidon_packages.sh`
 
 ### `Fixed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `scripts/prepare_eager_tsv.R`
     - `scripts/fill_in_janno.R`
 - Refactor how valid analysis types are determined in shell scripts, to make more easily extendable.
+- `scripts/prepare_eager_tsv.R`: Now uses Main_Individual_ID instead of Full_Individual_ID as the Sample_Name when one is provided.
 
 ### `Fixed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `scripts/prepare_eager_tsv.R`: 
   - Now uses Main_Individual_ID instead of Full_Individual_ID as the Sample_Name when one is provided.
   - Now excludes sequencing entries with the `Exclude` flag set to `Yes`.
-- `scripts/run_Eager.sh`: Java garbage collector now limited to one thread to avoid memory issues and hanging spawner jobs.
+- `scripts/create_processed_ind_list.sh`: Script to create a list of processed individuals across all analysis types, and a count of individuals in each analysis type.
 
 ### `Fixed`
+- `scripts/run_Eager.sh`: Java garbage collector now limited to one thread to avoid memory issues and hanging spawner jobs.
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `scripts/create_poseidon_release.sh`: New script to create large releases of the entire TF processed data in Poseidon format.
 - Now compatible with Pandora Site IDs longer than 3 letters.
   - The following scripts can now infer Site_ID of varied lengths from the Ind_ID (pyPandoraHelper):
-  - `scripts/clear_results.sh`
-  - `scripts/clear_work_dirs.sh`
-  - `scripts/ethical_sample_scrub.sh`
-  - `scripts/run_Eager.sh`
-  - `scripts/update_poseidon_packages.sh`
+    - `scripts/clear_results.sh`
+    - `scripts/clear_work_dirs.sh`
+    - `scripts/ethical_sample_scrub.sh`
+    - `scripts/run_Eager.sh`
+    - `scripts/update_poseidon_packages.sh`
   - The following scripts can now infer Site_ID of varied lengths from the Ind_ID (rPandoraHelper):
     - `scripts/prepare_eager_tsv.R`
     - `scripts/fill_in_janno.R`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `scripts/prepare_eager_tsv.R`: 
   - Now uses Main_Individual_ID instead of Full_Individual_ID as the Sample_Name when one is provided.
   - Now excludes sequencing entries with the `Exclude` flag set to `Yes`.
+- `scripts/run_Eager.sh`: Java garbage collector now limited to one thread to avoid memory issues and hanging spawner jobs.
 
 ### `Fixed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Added`
 
 - Processing of YC data. (Y + mtDNA capture (YMCA))
+- Processing of IM data. (Immunocapture)
 - `conf/Autorun.config`: 
   - Use hard links when publishing results, instead of copying files.
   - Add YC profile for processing YMCA data.
@@ -23,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The following scripts can now infer Site_ID of varied lengths from the Ind_ID (rPandoraHelper):
     - `scripts/prepare_eager_tsv.R`
     - `scripts/fill_in_janno.R`
+- Refactor how valid analysis types are determined in shell scripts, to make more easily extendable.
 
 ### `Fixed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `scripts/ethical_sample_scrub.sh`
   - `scripts/run_Eager.sh`
   - `scripts/update_poseidon_packages.sh`
+- The following scripts now use rPandoraHelper to infer Site_ID from Ind_ID:
+  - `scripts/prepare_eager_tsv.R`
+  - `scripts/fill_in_janno.R`
+- Now compatible with Pandora Site IDs longer than 3 letters.
 
 ### `Fixed`
 
 ### `Dependencies`
 
-- pyPandoraHelper=0.1.0
+- pyPandoraHelper=0.2.1
+- rPandoraHelper=0.2.0
 
 ### `Deprecated`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `scripts/prepare_eager_tsv.R`
     - `scripts/fill_in_janno.R`
 - Refactor how valid analysis types are determined in shell scripts, to make more easily extendable.
-- `scripts/prepare_eager_tsv.R`: Now uses Main_Individual_ID instead of Full_Individual_ID as the Sample_Name when one is provided.
+- `scripts/prepare_eager_tsv.R`: 
+  - Now uses Main_Individual_ID instead of Full_Individual_ID as the Sample_Name when one is provided.
+  - Now excludes sequencing entries with the `Exclude` flag set to `Yes`.
 
 ### `Fixed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `scripts/ethical_sample_scrub.sh`: Add RP analysis type for ethical sample scrubbing.
   - `scripts/clear_work_dirs.sh`: Add RP analysis type for work directory clearing.
   - `scripts/clear_results.sh`: Add RP analysis type for results directory clearing.
+- `scripts/update_poseidon_packages.sh`: Bump version for new release.
+- `README.md`: Updated to list new state of the pipeline.
 
 ### `Fixed`
 

--- a/conf/Autorun.config
+++ b/conf/Autorun.config
@@ -342,7 +342,7 @@ profiles {
       genotyping_tool     = 'hc'
       gatk_hc_out_mode    = 'EMIT_ALL_ACTIVE_SITES'
       gatk_hc_emitrefconf = 'GVCF'
-      //gatk_dbsnp = null
+      //gatk_dbsnp = null  // Decided not to add a dbSNP file for IM data, as it only provides some annotations.
 
       // BCF stats
       run_bcftools_stats = true
@@ -354,8 +354,15 @@ profiles {
       run_nuclear_contamination = true
       contamination_chrom_name  = 'X'
 
-      //1240k Coverage/Depth calculation (for poseidonisation)
+      //1240k Coverage/Depth calculation
       run_bedtools_coverage = true
+
+      // Local paths (to overwrite the ones in local_paths profile)
+      // Qualimap bedfile for on-target coverage calculation
+      snpcapture_bed        = '/mnt/archgen/Reference_Genomes/Human/hs37d5/SNPCapBEDs/IM_capture_hs37d5_HLAremoved.bed'
+
+      // SNP depth calculation
+      anno_file             = '/mnt/archgen/Reference_Genomes/Human/hs37d5/SNPCapBEDs/IM_capture_hs37d5_HLAremoved.bed'
     }
   }
 }

--- a/conf/Autorun.config
+++ b/conf/Autorun.config
@@ -364,5 +364,11 @@ profiles {
       // SNP depth calculation
       anno_file             = '/mnt/archgen/Reference_Genomes/Human/hs37d5/SNPCapBEDs/IM_capture_hs37d5_HLAremoved.bed'
     }
+
+    process {
+      withName: genotyping_hc {
+        memory = { task.attempt == 3 ? 48.GB : task.attempt == 2 ? 32.GB : 24.GB }
+      }
+    }
   }
 }

--- a/conf/Autorun.config
+++ b/conf/Autorun.config
@@ -250,4 +250,56 @@ profiles {
       run_bedtools_coverage = true
     }
   }
+
+  YC {
+    params{
+      // BAM filtering
+      run_bam_filtering = true           // Filter out unmapped reads, so barplots in MultiQC are not completely overtaken by unmapped reads.
+      bam_mapping_quality_threshold = 0   // Keep all mapped reads 
+      bam_unmapped_type = 'bam'          // Keep unmapped reads as a separate BAM file for possible future pathogen screening.
+      bam_filter_minreadlength = 30      // Do we need to add length filtering here at all? Does Kay's pre-processing do this?
+
+      // mtDNA to nuclear ratio
+      run_mtnucratio = true
+      mtnucratio_header = "MT"
+
+      // Bam Trimming
+      // ssDNA libraries are left untrimmed (pileupcaller deals with damage in those)
+      // dsDNA half-udg are clipped 2bp on either side, while non-UDG are clipper 7bp 
+      run_trim_bam = true
+      bamutils_clip_single_stranded_half_udg_left  = 0    // Set to 0 so ssDNA do not get trimmed.
+      bamutils_clip_single_stranded_half_udg_right = 0    // Set to 0 so ssDNA do not get trimmed.
+      bamutils_clip_single_stranded_none_udg_left  = 0    // Set to 0 so ssDNA do not get trimmed.
+      bamutils_clip_single_stranded_none_udg_right = 0    // Set to 0 so ssDNA do not get trimmed.
+      bamutils_clip_double_stranded_half_udg_left  = 2    // Trim 2 bp of either side for half-UDG libraries.
+      bamutils_clip_double_stranded_half_udg_right = 2    // Trim 2 bp of either side for half-UDG libraries.
+      // Usually for dsDNA non-UDG libraries this is between 5 and 10. I have set it to 7 arbitrarily since that was a good cutoff in my own projects so far.
+      bamutils_clip_double_stranded_none_udg_left  = 7    // Trim 7 bp of either side for non-UDG libraries.
+      bamutils_clip_double_stranded_none_udg_right = 7    // Trim 7 bp of either side for non-UDG libraries.
+
+      // Damage Calculation
+      damage_calculation_tool = 'mapdamage'
+      mapdamage_downsample = 100000 // Use 100k reads for damage calculation to lower runtime.
+
+      // Genotyping
+      run_genotyping = false
+
+      //Sex determination
+      run_sexdeterrmine = true
+
+      // Nuclear contamination
+      run_nuclear_contamination = true
+      contamination_chrom_name = 'X'
+
+      //1240k Coverage/Depth calculation (for poseidonisation)
+      run_bedtools_coverage = true
+
+      // Local paths (to overwrite the ones in local_paths profile)
+      // Qualimap bedfile for on-target coverage calculation
+      snpcapture_bed        = '/mnt/archgen/Reference_Genomes/Human/hs37d5/SNPCapBEDs/ISOGG_20_05_08_hs37d5.bed'
+
+      // 1240k depth calculation
+      anno_file             = '/mnt/archgen/Reference_Genomes/Human/hs37d5/SNPCapBEDs/ISOGG_20_05_08_hs37d5.bed'
+    }
+  }
 }

--- a/conf/Autorun.config
+++ b/conf/Autorun.config
@@ -8,6 +8,9 @@ profiles {
       // Specific nf-core/configs params
       config_profile_contact = 'Thiseas C. Lamnidis (@TCLamnidis)'
       config_profile_description = 'Autorun_eager profile for automated processing in EVA'
+      // 22/10/2024 Use harl links to publish the output files instead of copying them over.
+      //   This should decrease the I/O load to the server, thus lowering the chances of filesystem hiccups.
+      publish_dir_mode = 'link'
     }
 
     process {

--- a/conf/Autorun.config
+++ b/conf/Autorun.config
@@ -49,225 +49,22 @@ profiles {
   SG {
     params{
       // BAM filtering
-      run_bam_filtering = true           // Filter out unmapped reads, so barplots in MultiQC are not completely overtaken by unmapped reads.
-      bam_mapping_quality_threshold = 0   // Keep all mapped reads 
-      bam_unmapped_type = 'bam'          // Keep unmapped reads as a separate BAM file for possible future pathogen screening.
-      bam_filter_minreadlength = 30      // Do we need to add length filtering here at all? Does Kay's pre-processing do this?
+      run_bam_filtering             = true  // Filter out unmapped reads, so barplots in MultiQC are not completely overtaken by unmapped reads.
+      bam_mapping_quality_threshold = 0     // Keep all mapped reads 
+      bam_unmapped_type             = 'bam' // Keep unmapped reads as a separate BAM file for possible future pathogen screening.
+      bam_filter_minreadlength      = 30    // Do we need to add length filtering here at all? Does Kay's pre-processing do this?
 
       // mtDNA to nuclear ratio
-      run_mtnucratio = true
+      run_mtnucratio    = true
       mtnucratio_header = "MT"
 
       // Ignore SNP capture bed for coverage calculations in non TF data.
-      snpcapture_bed        = null
+      snpcapture_bed    = null
 
       // Bam Trimming
       // ssDNA libraries are left untrimmed (pileupcaller deals with damage in those)
       // dsDNA half-udg are clipped 2bp on either side, while non-UDG are clipper 7bp 
-      run_trim_bam = true
-      bamutils_clip_single_stranded_half_udg_left = 0     // Set to 0 so ssDNA do not get trimmed.
-      bamutils_clip_single_stranded_half_udg_right = 0    // Set to 0 so ssDNA do not get trimmed.
-      bamutils_clip_single_stranded_none_udg_left = 0     // Set to 0 so ssDNA do not get trimmed.
-      bamutils_clip_single_stranded_none_udg_right = 0    // Set to 0 so ssDNA do not get trimmed.
-      bamutils_clip_double_stranded_half_udg_left = 2     // Trim 2 bp of either side for half-UDG libraries.
-      bamutils_clip_double_stranded_half_udg_right = 2    // Trim 2 bp of either side for half-UDG libraries.
-      // Usually for dsDNA non-UDG libraries this is between 5 and 10. I have set it to 7 arbitrarily since that was a good cutoff in my own projects so far.
-      bamutils_clip_double_stranded_none_udg_left = 7     // Trim 7 bp of either side for non-UDG libraries.
-      bamutils_clip_double_stranded_none_udg_right = 7    // Trim 7 bp of either side for non-UDG libraries.
-
-      // Damage Calculation
-      damage_calculation_tool = 'mapdamage'
-      mapdamage_downsample = 100000 // Use 100k reads for damage calculation to lower runtime.
-
-      // Genotyping
-      genotyping_source = 'trimmed'           // Use trimmed bams for genotyping
-      run_genotyping = true
-      genotyping_tool = 'pileupcaller'
-      pileupcaller_min_map_quality = 25       // To allow for reads aligning with a mismatch, and reduce reference bias in genotypes.
-      pileupcaller_min_base_quality = 30
-
-      //Sex determination
-      run_sexdeterrmine = true
-
-      // Nuclear contamination
-      run_nuclear_contamination = true
-      contamination_chrom_name = 'X'
-
-      //1240k Coverage/Depth calculation (for poseidonisation)
-      run_bedtools_coverage = true
-    }
-  }
-
-  // Profile with parameters for runs using the Human_RP bams as input.
-  // Currently identical to SG profile, except it keeps the snpcapture_bed option.
-  TF {
-    params{
-      // BAM filtering
-      run_bam_filtering = true           // Filter out unmapped reads, so barplots in MultiQC are not completely overtaken by unmapped reads.
-      bam_mapping_quality_threshold = 0   // Keep all mapped reads 
-      bam_unmapped_type = 'bam'          // Keep unmapped reads as a separate BAM file for possible future pathogen screening.
-      bam_filter_minreadlength = 30      // Do we need to add length filtering here at all? Does Kay's pre-processing do this?
-
-      // mtDNA to nuclear ratio
-      run_mtnucratio = true
-      mtnucratio_header = "MT"
-
-      // Bam Trimming
-      // ssDNA libraries are left untrimmed (pileupcaller deals with damage in those)
-      // dsDNA half-udg are clipped 2bp on either side, while non-UDG are clipper 7bp 
-      run_trim_bam = true
-      bamutils_clip_single_stranded_half_udg_left = 0     // Set to 0 so ssDNA do not get trimmed.
-      bamutils_clip_single_stranded_half_udg_right = 0    // Set to 0 so ssDNA do not get trimmed.
-      bamutils_clip_single_stranded_none_udg_left = 0     // Set to 0 so ssDNA do not get trimmed.
-      bamutils_clip_single_stranded_none_udg_right = 0    // Set to 0 so ssDNA do not get trimmed.
-      bamutils_clip_double_stranded_half_udg_left = 2     // Trim 2 bp of either side for half-UDG libraries.
-      bamutils_clip_double_stranded_half_udg_right = 2    // Trim 2 bp of either side for half-UDG libraries.
-      // Usually for dsDNA non-UDG libraries this is between 5 and 10. I have set it to 7 arbitrarily since that was a good cutoff in my own projects so far.
-      bamutils_clip_double_stranded_none_udg_left = 7     // Trim 7 bp of either side for non-UDG libraries.
-      bamutils_clip_double_stranded_none_udg_right = 7    // Trim 7 bp of either side for non-UDG libraries.
-
-      // Damage Calculation
-      damage_calculation_tool = 'mapdamage'
-      mapdamage_downsample = 100000 // Use 100k reads for damage calculation to lower runtime.
-
-      // Genotyping
-      genotyping_source = 'trimmed'           // Use trimmed bams for genotyping
-      run_genotyping = true
-      genotyping_tool = 'pileupcaller'
-      pileupcaller_min_map_quality = 25       // To allow for reads aligning with a mismatch, and reduce reference bias in genotypes.
-      pileupcaller_min_base_quality = 30
-
-      //Sex determination
-      run_sexdeterrmine = true
-
-      // Nuclear contamination
-      run_nuclear_contamination = true
-      contamination_chrom_name = 'X'
-
-      //1240k Coverage/Depth calculation (for poseidonisation)
-      run_bedtools_coverage = true
-    }
-  }
-
-  // Profile with parameters for runs using the Human_RP bams as input.
-  // Currently identical to TF profile. Just keeps the RP data separate for comparison.
-  RP {
-    params{
-      // BAM filtering
-      run_bam_filtering = true           // Filter out unmapped reads, so barplots in MultiQC are not completely overtaken by unmapped reads.
-      bam_mapping_quality_threshold = 0   // Keep all mapped reads 
-      bam_unmapped_type = 'bam'          // Keep unmapped reads as a separate BAM file for possible future pathogen screening.
-      bam_filter_minreadlength = 30      // Do we need to add length filtering here at all? Does Kay's pre-processing do this?
-
-      // mtDNA to nuclear ratio
-      run_mtnucratio = true
-      mtnucratio_header = "MT"
-
-      // Bam Trimming
-      // ssDNA libraries are left untrimmed (pileupcaller deals with damage in those)
-      // dsDNA half-udg are clipped 2bp on either side, while non-UDG are clipper 7bp 
-      run_trim_bam = true
-      bamutils_clip_single_stranded_half_udg_left = 0     // Set to 0 so ssDNA do not get trimmed.
-      bamutils_clip_single_stranded_half_udg_right = 0    // Set to 0 so ssDNA do not get trimmed.
-      bamutils_clip_single_stranded_none_udg_left = 0     // Set to 0 so ssDNA do not get trimmed.
-      bamutils_clip_single_stranded_none_udg_right = 0    // Set to 0 so ssDNA do not get trimmed.
-      bamutils_clip_double_stranded_half_udg_left = 2     // Trim 2 bp of either side for half-UDG libraries.
-      bamutils_clip_double_stranded_half_udg_right = 2    // Trim 2 bp of either side for half-UDG libraries.
-      // Usually for dsDNA non-UDG libraries this is between 5 and 10. I have set it to 7 arbitrarily since that was a good cutoff in my own projects so far.
-      bamutils_clip_double_stranded_none_udg_left = 7     // Trim 7 bp of either side for non-UDG libraries.
-      bamutils_clip_double_stranded_none_udg_right = 7    // Trim 7 bp of either side for non-UDG libraries.
-
-      // Damage Calculation
-      damage_calculation_tool = 'mapdamage'
-      mapdamage_downsample = 100000 // Use 100k reads for damage calculation to lower runtime.
-
-      // Genotyping
-      genotyping_source = 'trimmed'           // Use trimmed bams for genotyping
-      run_genotyping = true
-      genotyping_tool = 'pileupcaller'
-      pileupcaller_min_map_quality = 25       // To allow for reads aligning with a mismatch, and reduce reference bias in genotypes.
-      pileupcaller_min_base_quality = 30
-
-      //Sex determination
-      run_sexdeterrmine = true
-
-      // Nuclear contamination
-      run_nuclear_contamination = true
-      contamination_chrom_name = 'X'
-
-      //1240k Coverage/Depth calculation (for poseidonisation)
-      run_bedtools_coverage = true
-    }
-  }
-
-  // Profile with parameters for runs using the Human_RM bams as input.
-  // Currently identical to TF profile. Just keeps the RP data separate for comparison.
-  RM {
-    params{
-      // BAM filtering
-      run_bam_filtering = true           // Filter out unmapped reads, so barplots in MultiQC are not completely overtaken by unmapped reads.
-      bam_mapping_quality_threshold = 0   // Keep all mapped reads 
-      bam_unmapped_type = 'bam'          // Keep unmapped reads as a separate BAM file for possible future pathogen screening.
-      bam_filter_minreadlength = 30      // Do we need to add length filtering here at all? Does Kay's pre-processing do this?
-
-      // mtDNA to nuclear ratio
-      run_mtnucratio = true
-      mtnucratio_header = "MT"
-
-      // Bam Trimming
-      // ssDNA libraries are left untrimmed (pileupcaller deals with damage in those)
-      // dsDNA half-udg are clipped 2bp on either side, while non-UDG are clipper 7bp 
-      run_trim_bam = true
-      bamutils_clip_single_stranded_half_udg_left = 0     // Set to 0 so ssDNA do not get trimmed.
-      bamutils_clip_single_stranded_half_udg_right = 0    // Set to 0 so ssDNA do not get trimmed.
-      bamutils_clip_single_stranded_none_udg_left = 0     // Set to 0 so ssDNA do not get trimmed.
-      bamutils_clip_single_stranded_none_udg_right = 0    // Set to 0 so ssDNA do not get trimmed.
-      bamutils_clip_double_stranded_half_udg_left = 2     // Trim 2 bp of either side for half-UDG libraries.
-      bamutils_clip_double_stranded_half_udg_right = 2    // Trim 2 bp of either side for half-UDG libraries.
-      // Usually for dsDNA non-UDG libraries this is between 5 and 10. I have set it to 7 arbitrarily since that was a good cutoff in my own projects so far.
-      bamutils_clip_double_stranded_none_udg_left = 7     // Trim 7 bp of either side for non-UDG libraries.
-      bamutils_clip_double_stranded_none_udg_right = 7    // Trim 7 bp of either side for non-UDG libraries.
-
-      // Damage Calculation
-      damage_calculation_tool = 'mapdamage'
-      mapdamage_downsample = 100000 // Use 100k reads for damage calculation to lower runtime.
-
-      // Genotyping
-      genotyping_source = 'trimmed'           // Use trimmed bams for genotyping
-      run_genotyping = true
-      genotyping_tool = 'pileupcaller'
-      pileupcaller_min_map_quality = 25       // To allow for reads aligning with a mismatch, and reduce reference bias in genotypes.
-      pileupcaller_min_base_quality = 30
-
-      //Sex determination
-      run_sexdeterrmine = true
-
-      // Nuclear contamination
-      run_nuclear_contamination = true
-      contamination_chrom_name = 'X'
-
-      //1240k Coverage/Depth calculation (for poseidonisation)
-      run_bedtools_coverage = true
-    }
-  }
-
-  // Profile with parameters for runs using the Human_Y bams as input.
-  YC {
-    params{
-      // BAM filtering
-      run_bam_filtering = true           // Filter out unmapped reads, so barplots in MultiQC are not completely overtaken by unmapped reads.
-      bam_mapping_quality_threshold = 0   // Keep all mapped reads 
-      bam_unmapped_type = 'bam'          // Keep unmapped reads as a separate BAM file for possible future pathogen screening.
-      bam_filter_minreadlength = 30      // Do we need to add length filtering here at all? Does Kay's pre-processing do this?
-
-      // mtDNA to nuclear ratio
-      run_mtnucratio = true
-      mtnucratio_header = "MT"
-
-      // Bam Trimming
-      // ssDNA libraries are left untrimmed (pileupcaller deals with damage in those)
-      // dsDNA half-udg are clipped 2bp on either side, while non-UDG are clipper 7bp 
-      run_trim_bam = true
+      run_trim_bam                                 = true
       bamutils_clip_single_stranded_half_udg_left  = 0    // Set to 0 so ssDNA do not get trimmed.
       bamutils_clip_single_stranded_half_udg_right = 0    // Set to 0 so ssDNA do not get trimmed.
       bamutils_clip_single_stranded_none_udg_left  = 0    // Set to 0 so ssDNA do not get trimmed.
@@ -280,7 +77,210 @@ profiles {
 
       // Damage Calculation
       damage_calculation_tool = 'mapdamage'
-      mapdamage_downsample = 100000 // Use 100k reads for damage calculation to lower runtime.
+      mapdamage_downsample    = 100000 // Use 100k reads for damage calculation to lower runtime.
+
+      // Genotyping
+      genotyping_source             = 'trimmed'      // Use trimmed bams for genotyping
+      run_genotyping                = true
+      genotyping_tool               = 'pileupcaller'
+      pileupcaller_min_map_quality  = 25             // To allow for reads aligning with a mismatch, and reduce reference bias in genotypes.
+      pileupcaller_min_base_quality = 30
+
+      //Sex determination
+      run_sexdeterrmine = true
+
+      // Nuclear contamination
+      run_nuclear_contamination = true
+      contamination_chrom_name  = 'X'
+
+      //1240k Coverage/Depth calculation (for poseidonisation)
+      run_bedtools_coverage = true
+    }
+  }
+
+  // Profile with parameters for runs using the Human_RP bams as input.
+  // Currently identical to SG profile, except it keeps the snpcapture_bed option.
+  TF {
+    params{
+      // BAM filtering
+      run_bam_filtering             = true  // Filter out unmapped reads, so barplots in MultiQC are not completely overtaken by unmapped reads.
+      bam_mapping_quality_threshold = 0     // Keep all mapped reads 
+      bam_unmapped_type             = 'bam' // Keep unmapped reads as a separate BAM file for possible future pathogen screening.
+      bam_filter_minreadlength      = 30    // Do we need to add length filtering here at all? Does Kay's pre-processing do this?
+
+      // mtDNA to nuclear ratio
+      run_mtnucratio    = true
+      mtnucratio_header = "MT"
+
+      // Bam Trimming
+      // ssDNA libraries are left untrimmed (pileupcaller deals with damage in those)
+      // dsDNA half-udg are clipped 2bp on either side, while non-UDG are clipper 7bp 
+      run_trim_bam                                 = true
+      bamutils_clip_single_stranded_half_udg_left  = 0    // Set to 0 so ssDNA do not get trimmed.
+      bamutils_clip_single_stranded_half_udg_right = 0    // Set to 0 so ssDNA do not get trimmed.
+      bamutils_clip_single_stranded_none_udg_left  = 0    // Set to 0 so ssDNA do not get trimmed.
+      bamutils_clip_single_stranded_none_udg_right = 0    // Set to 0 so ssDNA do not get trimmed.
+      bamutils_clip_double_stranded_half_udg_left  = 2    // Trim 2 bp of either side for half-UDG libraries.
+      bamutils_clip_double_stranded_half_udg_right = 2    // Trim 2 bp of either side for half-UDG libraries.
+      // Usually for dsDNA non-UDG libraries this is between 5 and 10. I have set it to 7 arbitrarily since that was a good cutoff in my own projects so far.
+      bamutils_clip_double_stranded_none_udg_left  = 7    // Trim 7 bp of either side for non-UDG libraries.
+      bamutils_clip_double_stranded_none_udg_right = 7    // Trim 7 bp of either side for non-UDG libraries.
+
+      // Damage Calculation
+      damage_calculation_tool = 'mapdamage'
+      mapdamage_downsample    = 100000 // Use 100k reads for damage calculation to lower runtime.
+
+      // Genotyping
+      genotyping_source             = 'trimmed'      // Use trimmed bams for genotyping
+      run_genotyping                = true
+      genotyping_tool               = 'pileupcaller'
+      pileupcaller_min_map_quality  = 25             // To allow for reads aligning with a mismatch, and reduce reference bias in genotypes.
+      pileupcaller_min_base_quality = 30
+
+      //Sex determination
+      run_sexdeterrmine = true
+
+      // Nuclear contamination
+      run_nuclear_contamination = true
+      contamination_chrom_name  = 'X'
+
+      //1240k Coverage/Depth calculation (for poseidonisation)
+      run_bedtools_coverage = true
+    }
+  }
+
+  // Profile with parameters for runs using the Human_RP bams as input.
+  // Currently identical to TF profile. Just keeps the RP data separate for comparison.
+  RP {
+    params{
+      // BAM filtering
+      run_bam_filtering             = true  // Filter out unmapped reads, so barplots in MultiQC are not completely overtaken by unmapped reads.
+      bam_mapping_quality_threshold = 0     // Keep all mapped reads 
+      bam_unmapped_type             = 'bam' // Keep unmapped reads as a separate BAM file for possible future pathogen screening.
+      bam_filter_minreadlength      = 30    // Do we need to add length filtering here at all? Does Kay's pre-processing do this?
+
+      // mtDNA to nuclear ratio
+      run_mtnucratio    = true
+      mtnucratio_header = "MT"
+
+      // Bam Trimming
+      // ssDNA libraries are left untrimmed (pileupcaller deals with damage in those)
+      // dsDNA half-udg are clipped 2bp on either side, while non-UDG are clipper 7bp 
+      run_trim_bam                                 = true
+      bamutils_clip_single_stranded_half_udg_left  = 0    // Set to 0 so ssDNA do not get trimmed.
+      bamutils_clip_single_stranded_half_udg_right = 0    // Set to 0 so ssDNA do not get trimmed.
+      bamutils_clip_single_stranded_none_udg_left  = 0    // Set to 0 so ssDNA do not get trimmed.
+      bamutils_clip_single_stranded_none_udg_right = 0    // Set to 0 so ssDNA do not get trimmed.
+      bamutils_clip_double_stranded_half_udg_left  = 2    // Trim 2 bp of either side for half-UDG libraries.
+      bamutils_clip_double_stranded_half_udg_right = 2    // Trim 2 bp of either side for half-UDG libraries.
+      // Usually for dsDNA non-UDG libraries this is between 5 and 10. I have set it to 7 arbitrarily since that was a good cutoff in my own projects so far.
+      bamutils_clip_double_stranded_none_udg_left  = 7    // Trim 7 bp of either side for non-UDG libraries.
+      bamutils_clip_double_stranded_none_udg_right = 7    // Trim 7 bp of either side for non-UDG libraries.
+
+      // Damage Calculation
+      damage_calculation_tool = 'mapdamage'
+      mapdamage_downsample    = 100000 // Use 100k reads for damage calculation to lower runtime.
+
+      // Genotyping
+      genotyping_source             = 'trimmed'      // Use trimmed bams for genotyping
+      run_genotyping                = true
+      genotyping_tool               = 'pileupcaller'
+      pileupcaller_min_map_quality  = 25             // To allow for reads aligning with a mismatch, and reduce reference bias in genotypes.
+      pileupcaller_min_base_quality = 30
+
+      //Sex determination
+      run_sexdeterrmine = true
+
+      // Nuclear contamination
+      run_nuclear_contamination = true
+      contamination_chrom_name  = 'X'
+
+      //1240k Coverage/Depth calculation (for poseidonisation)
+      run_bedtools_coverage = true
+    }
+  }
+
+  // Profile with parameters for runs using the Human_RM bams as input.
+  // Currently identical to TF profile. Just keeps the RP data separate for comparison.
+  RM {
+    params{
+      // BAM filtering
+      run_bam_filtering             = true  // Filter out unmapped reads, so barplots in MultiQC are not completely overtaken by unmapped reads.
+      bam_mapping_quality_threshold = 0     // Keep all mapped reads 
+      bam_unmapped_type             = 'bam' // Keep unmapped reads as a separate BAM file for possible future pathogen screening.
+      bam_filter_minreadlength      = 30    // Do we need to add length filtering here at all? Does Kay's pre-processing do this?
+
+      // mtDNA to nuclear ratio
+      run_mtnucratio    = true
+      mtnucratio_header = "MT"
+
+      // Bam Trimming
+      // ssDNA libraries are left untrimmed (pileupcaller deals with damage in those)
+      // dsDNA half-udg are clipped 2bp on either side, while non-UDG are clipper 7bp 
+      run_trim_bam                                 = true
+      bamutils_clip_single_stranded_half_udg_left  = 0    // Set to 0 so ssDNA do not get trimmed.
+      bamutils_clip_single_stranded_half_udg_right = 0    // Set to 0 so ssDNA do not get trimmed.
+      bamutils_clip_single_stranded_none_udg_left  = 0    // Set to 0 so ssDNA do not get trimmed.
+      bamutils_clip_single_stranded_none_udg_right = 0    // Set to 0 so ssDNA do not get trimmed.
+      bamutils_clip_double_stranded_half_udg_left  = 2    // Trim 2 bp of either side for half-UDG libraries.
+      bamutils_clip_double_stranded_half_udg_right = 2    // Trim 2 bp of either side for half-UDG libraries.
+      // Usually for dsDNA non-UDG libraries this is between 5 and 10. I have set it to 7 arbitrarily since that was a good cutoff in my own projects so far.
+      bamutils_clip_double_stranded_none_udg_left  = 7    // Trim 7 bp of either side for non-UDG libraries.
+      bamutils_clip_double_stranded_none_udg_right = 7    // Trim 7 bp of either side for non-UDG libraries.
+
+      // Damage Calculation
+      damage_calculation_tool = 'mapdamage'
+      mapdamage_downsample    = 100000 // Use 100k reads for damage calculation to lower runtime.
+
+      // Genotyping
+      genotyping_source             = 'trimmed'      // Use trimmed bams for genotyping
+      run_genotyping                = true
+      genotyping_tool               = 'pileupcaller'
+      pileupcaller_min_map_quality  = 25             // To allow for reads aligning with a mismatch, and reduce reference bias in genotypes.
+      pileupcaller_min_base_quality = 30
+
+      //Sex determination
+      run_sexdeterrmine = true
+
+      // Nuclear contamination
+      run_nuclear_contamination = true
+      contamination_chrom_name  = 'X'
+
+      //1240k Coverage/Depth calculation (for poseidonisation)
+      run_bedtools_coverage = true
+    }
+  }
+
+  // Profile with parameters for runs using the Human_Y bams as input.
+  YC {
+    params{
+      // BAM filtering
+      run_bam_filtering             = true  // Filter out unmapped reads, so barplots in MultiQC are not completely overtaken by unmapped reads.
+      bam_mapping_quality_threshold = 0     // Keep all mapped reads 
+      bam_unmapped_type             = 'bam' // Keep unmapped reads as a separate BAM file for possible future pathogen screening.
+      bam_filter_minreadlength      = 30    // Do we need to add length filtering here at all? Does Kay's pre-processing do this?
+
+      // mtDNA to nuclear ratio
+      run_mtnucratio    = true
+      mtnucratio_header = "MT"
+
+      // Bam Trimming
+      // ssDNA libraries are left untrimmed (pileupcaller deals with damage in those)
+      // dsDNA half-udg are clipped 2bp on either side, while non-UDG are clipper 7bp 
+      run_trim_bam                                 = true
+      bamutils_clip_single_stranded_half_udg_left  = 0    // Set to 0 so ssDNA do not get trimmed.
+      bamutils_clip_single_stranded_half_udg_right = 0    // Set to 0 so ssDNA do not get trimmed.
+      bamutils_clip_single_stranded_none_udg_left  = 0    // Set to 0 so ssDNA do not get trimmed.
+      bamutils_clip_single_stranded_none_udg_right = 0    // Set to 0 so ssDNA do not get trimmed.
+      bamutils_clip_double_stranded_half_udg_left  = 2    // Trim 2 bp of either side for half-UDG libraries.
+      bamutils_clip_double_stranded_half_udg_right = 2    // Trim 2 bp of either side for half-UDG libraries.
+      // Usually for dsDNA non-UDG libraries this is between 5 and 10. I have set it to 7 arbitrarily since that was a good cutoff in my own projects so far.
+      bamutils_clip_double_stranded_none_udg_left  = 7    // Trim 7 bp of either side for non-UDG libraries.
+      bamutils_clip_double_stranded_none_udg_right = 7    // Trim 7 bp of either side for non-UDG libraries.
+
+      // Damage Calculation
+      damage_calculation_tool = 'mapdamage'
+      mapdamage_downsample    = 100000 // Use 100k reads for damage calculation to lower runtime.
 
       // Genotyping
       run_genotyping = false
@@ -290,7 +290,7 @@ profiles {
 
       // Nuclear contamination
       run_nuclear_contamination = true
-      contamination_chrom_name = 'X'
+      contamination_chrom_name  = 'X'
 
       //1240k Coverage/Depth calculation (for poseidonisation)
       run_bedtools_coverage = true
@@ -299,7 +299,7 @@ profiles {
       // Qualimap bedfile for on-target coverage calculation
       snpcapture_bed        = '/mnt/archgen/Reference_Genomes/Human/hs37d5/SNPCapBEDs/ISOGG_20_05_08_hs37d5.bed'
 
-      // 1240k depth calculation
+      // SNP depth calculation
       anno_file             = '/mnt/archgen/Reference_Genomes/Human/hs37d5/SNPCapBEDs/ISOGG_20_05_08_hs37d5.bed'
     }
   }
@@ -308,10 +308,10 @@ profiles {
   IM {
     params{
       // BAM filtering
-      run_bam_filtering = true           // Filter out unmapped reads, so barplots in MultiQC are not completely overtaken by unmapped reads.
-      bam_mapping_quality_threshold = 0   // Keep all mapped reads 
-      bam_unmapped_type = 'bam'          // Keep unmapped reads as a separate BAM file for possible future pathogen screening.
-      bam_filter_minreadlength = 30      // Do we need to add length filtering here at all? Does Kay's pre-processing do this?
+      run_bam_filtering             = true  // Filter out unmapped reads, so barplots in MultiQC are not completely overtaken by unmapped reads.
+      bam_mapping_quality_threshold = 0     // Keep all mapped reads 
+      bam_unmapped_type             = 'bam' // Keep unmapped reads as a separate BAM file for possible future pathogen screening.
+      bam_filter_minreadlength      = 30    // Do we need to add length filtering here at all? Does Kay's pre-processing do this?
 
       // mtDNA to nuclear ratio
       run_mtnucratio = true
@@ -320,7 +320,7 @@ profiles {
       // Bam Trimming
       // ssDNA libraries are left untrimmed (pileupcaller deals with damage in those)
       // dsDNA half-udg are clipped 2bp on either side, while non-UDG are clipper 7bp 
-      run_trim_bam = true
+      run_trim_bam                                 = true
       // Trim 2 bp on all udg-half libs, and 7 on all non-udg libs.
       // Since genotyping happens with GATK HC for IM results, no exception is made for ssDNA libs.
       bamutils_clip_single_stranded_half_udg_left  = 2    // Trim 2 bp of either side for half-UDG libraries.
@@ -334,13 +334,13 @@ profiles {
 
       // Damage Calculation
       damage_calculation_tool = 'mapdamage'
-      mapdamage_downsample = 100000 // Use 100k reads for damage calculation to lower runtime.
+      mapdamage_downsample    = 100000 // Use 100k reads for damage calculation to lower runtime.
 
       // Genotyping
-      genotyping_source = 'trimmed'           // Use trimmed bams for genotyping
-      run_genotyping = true
-      genotyping_tool = 'hc'
-      gatk_hc_out_mode = 'EMIT_ALL_ACTIVE_SITES'
+      genotyping_source   = 'trimmed'  // Use trimmed bams for genotyping
+      run_genotyping      = true
+      genotyping_tool     = 'hc'
+      gatk_hc_out_mode    = 'EMIT_ALL_ACTIVE_SITES'
       gatk_hc_emitrefconf = 'GVCF'
       //gatk_dbsnp = null
 
@@ -352,7 +352,7 @@ profiles {
 
       // Nuclear contamination
       run_nuclear_contamination = true
-      contamination_chrom_name = 'X'
+      contamination_chrom_name  = 'X'
 
       //1240k Coverage/Depth calculation (for poseidonisation)
       run_bedtools_coverage = true

--- a/conf/Autorun.config
+++ b/conf/Autorun.config
@@ -251,6 +251,7 @@ profiles {
     }
   }
 
+  // Profile with parameters for runs using the Human_Y bams as input.
   YC {
     params{
       // BAM filtering
@@ -300,6 +301,61 @@ profiles {
 
       // 1240k depth calculation
       anno_file             = '/mnt/archgen/Reference_Genomes/Human/hs37d5/SNPCapBEDs/ISOGG_20_05_08_hs37d5.bed'
+    }
+  }
+
+  // Profile with parameters for runs using the Human_IM bams as input.
+  IM {
+    params{
+      // BAM filtering
+      run_bam_filtering = true           // Filter out unmapped reads, so barplots in MultiQC are not completely overtaken by unmapped reads.
+      bam_mapping_quality_threshold = 0   // Keep all mapped reads 
+      bam_unmapped_type = 'bam'          // Keep unmapped reads as a separate BAM file for possible future pathogen screening.
+      bam_filter_minreadlength = 30      // Do we need to add length filtering here at all? Does Kay's pre-processing do this?
+
+      // mtDNA to nuclear ratio
+      run_mtnucratio = true
+      mtnucratio_header = "MT"
+
+      // Bam Trimming
+      // ssDNA libraries are left untrimmed (pileupcaller deals with damage in those)
+      // dsDNA half-udg are clipped 2bp on either side, while non-UDG are clipper 7bp 
+      run_trim_bam = true
+      // Trim 2 bp on all udg-half libs, and 7 on all non-udg libs.
+      // Since genotyping happens with GATK HC for IM results, no exception is made for ssDNA libs.
+      bamutils_clip_single_stranded_half_udg_left  = 2    // Trim 2 bp of either side for half-UDG libraries.
+      bamutils_clip_single_stranded_half_udg_right = 2    // Trim 2 bp of either side for half-UDG libraries.
+      bamutils_clip_single_stranded_none_udg_left  = 7    // Trim 7 bp of either side for half-UDG libraries.
+      bamutils_clip_single_stranded_none_udg_right = 7    // Trim 7 bp of either side for half-UDG libraries.
+      bamutils_clip_double_stranded_half_udg_left  = 2    // Trim 2 bp of either side for half-UDG libraries.
+      bamutils_clip_double_stranded_half_udg_right = 2    // Trim 2 bp of either side for half-UDG libraries.
+      bamutils_clip_double_stranded_none_udg_left  = 7    // Trim 7 bp of either side for non-UDG libraries.
+      bamutils_clip_double_stranded_none_udg_right = 7    // Trim 7 bp of either side for non-UDG libraries.
+
+      // Damage Calculation
+      damage_calculation_tool = 'mapdamage'
+      mapdamage_downsample = 100000 // Use 100k reads for damage calculation to lower runtime.
+
+      // Genotyping
+      genotyping_source = 'trimmed'           // Use trimmed bams for genotyping
+      run_genotyping = true
+      genotyping_tool = 'hc'
+      gatk_hc_out_mode = 'EMIT_ALL_ACTIVE_SITES'
+      gatk_hc_emitrefconf = 'GVCF'
+      //gatk_dbsnp = null
+
+      // BCF stats
+      run_bcftools_stats = true
+
+      //Sex determination
+      run_sexdeterrmine = true
+
+      // Nuclear contamination
+      run_nuclear_contamination = true
+      contamination_chrom_name = 'X'
+
+      //1240k Coverage/Depth calculation (for poseidonisation)
+      run_bedtools_coverage = true
     }
   }
 }

--- a/scripts/clear_results.sh
+++ b/scripts/clear_results.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+## DEPENDENCY
+pandora_helper="/mnt/archgen/tools/helper_scripts/py_helpers/pyPandoraHelper/pyPandoraHelper.py"
+
 ## This script removes the results for an individiaul while maintaining the nextflow process cache for them.
 ##    It is intended as a way to refresh the results directories of an individual. This can be useful either
 ##    to remove older files after additional libraries appear and are therefore merged, or to remove results
@@ -79,7 +82,7 @@ input_iids=($(cat ${ind_id_list_fn}))
 ##    Both needed for caching. 
 ##    Also leave '1240k.imputed' and 'GTL_output' alone.
 for ind_id in ${input_iids[@]}; do
-  site_id=${ind_id:0:3} ## Site id is the first three characters of the individual ID
+  site_id=`${pandora_helper} -g site_id ${ind_id}` ## Site inferred by pyPandoraHelper
   dirs_to_delete=$(ls -1 -d ${root_eager_dir}/${analysis_type}/${site_id}/${ind_id}/* | grep -vw -e 'work' -e '1240k.imputed' -e 'GTL_output' -e 'pipeline_info')
   for dir in ${dirs_to_delete}; do
     errecho "Deleting results in: ${dir}"

--- a/scripts/clear_results.sh
+++ b/scripts/clear_results.sh
@@ -1,21 +1,31 @@
 #!/usr/bin/env bash
 
-## DEPENDENCY
-pandora_helper="/mnt/archgen/tools/helper_scripts/py_helpers/pyPandoraHelper/pyPandoraHelper.py"
 
-## This script removes the results for an individiaul while maintaining the nextflow process cache for them.
+## This script removes the results for an individual while maintaining the nextflow process cache for them.
 ##    It is intended as a way to refresh the results directories of an individual. This can be useful either
 ##    to remove older files after additional libraries appear and are therefore merged, or to remove results
 ##    with misleading names in cases where Pandora entries get updated (e.g. protocol mixup leading to changes
 ##    in strandedness for a library).
 
+## DEPENDENCY
+pandora_helper="/mnt/archgen/tools/helper_scripts/py_helpers/pyPandoraHelper/pyPandoraHelper.py"
+
+valid_analysis_types=("TF" "SG" "RP" "RM" "IM" "YC")
+
+## Join array elements by separator given as $1
+function join_array_elements() {
+  local IFS="$1"
+  shift
+  echo "$*"
+}
+
 ## Helptext function
 function Helptext() {
-  echo -ne "\t usage: $0 [options] <ind_id_list>\n\n"
-  echo -ne "This script removes all output directory contents for the provided individuals, without clearing out caching, allowing for the results to be re-published.\n    This enables refreshing of result directories when changes to the input might have changes merging of libraries, thus making the directory structure inconsistent.\n\n"
-  echo -ne "Options:\n"
-  echo -ne "-h, --help\t\tPrint this text and exit.\n"
-  echo -ne "-a, --analysis_type\t\tSet the analysis type. Options: TF, SG, RP, RM.\n"
+  errecho "\t usage: $0 [options] <ind_id_list>\n"
+  errecho "This script removes all output directory contents for the provided individuals, without clearing out caching, allowing for the results to be re-published.\n    This enables refreshing of result directories when changes to the input might have changes merging of libraries, thus making the directory structure inconsistent.\n"
+  errecho "Options:"
+  errecho "-h, --help\t\tPrint this text and exit."
+  errecho "-a, --analysis_type\t\tSet the analysis type. Options: $(join_array_elements , ${valid_analysis_types[@]})."
 }
 
 ## Print messages to stderr, optionally with colours
@@ -36,6 +46,8 @@ function errecho() {
   elif [[ ${1} == '-r' ]]; then
     colour="${Red}"
     shift 1
+  else
+    colour="${Normal}"
   fi
   echo -e ${colour}$*${Normal} 1>&2
 }
@@ -68,9 +80,11 @@ fi
 if [[ ${analysis_type} == '' ]]; then
   errecho "No --analysis_type was provided.\n"
   Helptext
-elif [[ ${analysis_type} != "SG" && ${analysis_type} != "TF" && ${analysis_type} != "RP" && ${analysis_type} != "RM" ]]; then
-  errecho "analysis_type must be SG, TF, RP, or RM. You provided: ${analysis_type}\n"
+  exit 2
+elif [[ ! " ${valid_analysis_types[*]} " =~ " ${analysis_type} " ]]; then
+  errecho "analysis_type must be one of: $(join_array_elements , ${valid_analysis_types[@]}). You provided: ${analysis_type}\n"
   Helptext
+  exit 2
 fi
 
 root_eager_dir='/mnt/archgen/Autorun_eager/eager_outputs' ## Directory should include subdirectories for each analysis type (TF/SG) and sub-subdirectories for each site and individual.

--- a/scripts/clear_work_dirs.sh
+++ b/scripts/clear_work_dirs.sh
@@ -2,6 +2,9 @@
 
 ## This script accepts a list of individual IDs and clears the nextflow work directories for both SG and TF data processing of each ID.
 
+## DEPENDENCY
+pandora_helper="/mnt/archgen/tools/helper_scripts/py_helpers/pyPandoraHelper/pyPandoraHelper.py"
+
 ## Helptext function
 function Helptext() {
   echo -ne "\t usage: $0 [options] <ind_id_list>\n\n"
@@ -40,7 +43,7 @@ root_eager_dir='/mnt/archgen/Autorun_eager/eager_outputs' ## Directory should in
 input_iids=($(cat ${ind_id_list_fn}))
 
 for ind_id in ${input_iids[@]}; do
-  site_id=${ind_id:0:3} ## Site id is the first three characters of the individual ID
+  site_id=`${pandora_helper} -g site_id ${ind_id}` ## Site inferred by pyPandoraHelper
   errecho -ne "Clearing work directories for ${ind_id}..."
   for analysis_type in "SG" "TF" "RP" "RM"; do
     if [[ -d ${root_eager_dir}/${analysis_type}/${site_id}/${ind_id}/work ]]; then

--- a/scripts/clear_work_dirs.sh
+++ b/scripts/clear_work_dirs.sh
@@ -5,10 +5,12 @@
 ## DEPENDENCY
 pandora_helper="/mnt/archgen/tools/helper_scripts/py_helpers/pyPandoraHelper/pyPandoraHelper.py"
 
+valid_analysis_types=("TF" "SG" "RP" "RM" "IM" "YC")
+
 ## Helptext function
 function Helptext() {
   echo -ne "\t usage: $0 [options] <ind_id_list>\n\n"
-  echo -ne "This script clears the work directories of individuals in a specified individual ID list from both the SG and TF results directories.\n\n"
+  echo -ne "This script clears the work directories of individuals in a specified individual ID list from all results directories.\n\n"
   echo -ne "Options:\n"
   echo -ne "-h, --help\t\tPrint this text and exit.\n"
 }
@@ -45,7 +47,7 @@ input_iids=($(cat ${ind_id_list_fn}))
 for ind_id in ${input_iids[@]}; do
   site_id=`${pandora_helper} -g site_id ${ind_id}` ## Site inferred by pyPandoraHelper
   errecho -ne "Clearing work directories for ${ind_id}..."
-  for analysis_type in "SG" "TF" "RP" "RM"; do
+  for analysis_type in ${valid_analysis_types[@]}; do
     if [[ -d ${root_eager_dir}/${analysis_type}/${site_id}/${ind_id}/work ]]; then
       errecho -ne " ${analysis_type}..."
       # ls -d ${root_eager_dir}/${analysis_type}/${site_id}/${ind_id}/work

--- a/scripts/create_poseidon_release.sh
+++ b/scripts/create_poseidon_release.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+VERSION="1.0.0"
+
+## Colours for printing to terminal
+Yellow=$(tput sgr0)'\033[1;33m' ## Yellow normal face
+Red=$(tput sgr0)'\033[1;31m' ## Red normal face
+Normal=$(tput sgr0)
+
+## Helptext function
+function Helptext() {
+  echo -ne "\t usage: $0 [options] <release_name>\n\n"
+  echo -ne "This creates a dated release of all poseidon packages.\n\n"
+  echo -ne "Options:\n"
+  echo -ne "-h, --help\t\tPrint this text and exit.\n"
+  echo -ne "-v, --version \t\tPrint version and exit.\n"
+}
+
+## Print messages to stderr
+function errecho() { echo -e $* 1>&2 ;}
+
+
+## Parse CLI args.
+TEMP=`getopt -q -o hv --long help,version -n 'create_poseidon_release.sh' -- "$@"`  
+eval set -- "$TEMP"
+
+## parameter defaults
+trident_path="/r1/people/srv_autoeager/bin/trident-1.5.7.0"
+## In the future, maybe multiple releases, for each data type?
+poseidon_pacakges="/mnt/archgen/Autorun_eager/poseidon_packages/TF/Sites/"
+release_dir="/mnt/archgen/Autorun_eager/poseidon_packages/releases/"
+
+## Read in CLI arguments
+while true ; do
+  case "$1" in
+    -h|--help) Helptext; exit 0 ;;
+    -v|--version) echo ${VERSION}; exit 0;;
+    --) release_name="${2}"; break ;;
+    *) echo -e "invalid option provided: $1.\n"; Helptext; exit 1;;
+  esac
+done
+
+## All poseidon packages have the population name "Unknown". This can be used to make a mega release easily.
+##   Once the large dataset is created, the population name can be changed to the site name.
+## TODO: a) Submit to scheduler, b) First forge each site, then forge across sites. That limits open file handles and speeds things up considerably.
+CMD="${trident_path} forge \
+  -d ${poseidon_pacakges} \
+  --forgeString Unknown \
+  --outFormat EIGENSTRAT \
+  --outPackagePath ${release_dir}/${release_name} \
+  --outPackageName ${release_name} \
+  --logMode SimpleLog"
+
+errecho "${CMD}" | tr -s ' '
+${CMD} 2>&1 > ${release_dir}/${release_name}.creation_log
+
+if [[ $? -ne 0 ]]; then
+  errecho "${Red}Error${Normal}: Trident failed to create the release. Check the log file for more information."
+  exit 1
+fi
+
+## Update Group_Name column in ind file
+awk -F "\t" -v OFS="\t" '{if ($1 ~ /_ss$/) {$3 = substr($1, 1,length($1)-6)} else {$3 = substr($1, 1,length($1)-3)}; print $0}' ${release_dir}/${release_name}.ind > ${release_dir}/${release_name}.ind.tmp
+mv ${release_dir}/${release_name}.ind ${release_dir}/.${release_name}.ind.original
+mv ${release_dir}/${release_name}.ind.tmp ${release_dir}/${release_name}.ind
+
+## Update Group_Name column in janno file
+##    janno has  aheader line, so add NR==1; NR > 1 to only apply the transformation after the first line.
+awk -F "\t" -v OFS="\t" 'NR==1; NR > 1{if ($1 ~ /_ss$/) {$3 = substr($1, 1,length($1)-6)} else {$3 = substr($1, 1,length($1)-3)}; print $0}' ${release_dir}/${release_name}.janno > ${release_dir}/${release_name}.janno.tmp
+mv ${release_dir}/${release_name}.janno ${release_dir}/.${release_name}.janno.original
+mv ${release_dir}/${release_name}.janno.tmp ${release_dir}/${release_name}.janno
+
+## Rectify the package to add checksums
+CMD="${trident_path} rectify \
+  -d ${release_dir}/${release_name} \
+  --packageVersion Minor \
+  --logText 'Added checksums to package' \
+  --checksumAll"
+
+errecho "${CMD}" | tr -s ' '
+${CMD}

--- a/scripts/create_processed_ind_list.sh
+++ b/scripts/create_processed_ind_list.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+date=$(date +'%y%m%d_%H%M')
+
+cd /mnt/archgen/Autorun_eager/
+
+if [[ ! -d stats/${date} ]]; then
+	mkdir stats/${date}/
+fi
+
+find /mnt/archgen/Autorun_eager/eager_outputs -maxdepth 4 -mindepth 4 -path '*/*/*/multiqc' -type d | rev | cut -d "/" -f 2 | rev > stats/${date}/all_processed_inds_${date}.tsv
+
+sort -u stats/${date}/all_processed_inds_${date}.tsv > stats/${date}/all_processed_inds_${date}_unique.txt
+
+(for a in `ls eager_outputs/`; do echo -n "${a} individuals processed: "; find /mnt/archgen/Autorun_eager/eager_outputs/${a} -maxdepth 4 -mindepth 4 -path '*/*/*/multiqc/multiqc_report.html' -type f  | wc -l ; done ; echo "Date: ${date}") > stats/${date}/n_processed_inds_${date}.txt

--- a/scripts/cron_daily_prepare.sh
+++ b/scripts/cron_daily_prepare.sh
@@ -33,3 +33,10 @@ find /mnt/archgen/Autorun/Results/Human_RM/2* -name '*.bam' -mtime -1 2>/dev/nul
     echo "Processing RM data from run: ${RUN}"
     scripts/prepare_eager_tsv.R -s $RUN -a RM -o eager_inputs/ -d .eva_credentials
 done
+
+# Y + mtDNA capture (YMCA)
+# Note: this find only checks runs starting from 2020.  Silence stderr to avoid 'permission denied'.
+find /mnt/archgen/Autorun/Results/Human_Y/2* -name '*.bam' -mtime -1 2>/dev/null | cut -f 7 -d "/" | sort -u | while read RUN ; do
+    echo "Processing YC data from run: ${RUN}"
+    scripts/prepare_eager_tsv.R -s $RUN -a YC -o eager_inputs/ -d .eva_credentials
+done

--- a/scripts/cron_daily_prepare.sh
+++ b/scripts/cron_daily_prepare.sh
@@ -40,3 +40,10 @@ find /mnt/archgen/Autorun/Results/Human_Y/2* -name '*.bam' -mtime -1 2>/dev/null
     echo "Processing YC data from run: ${RUN}"
     scripts/prepare_eager_tsv.R -s $RUN -a YC -o eager_inputs/ -d .eva_credentials
 done
+
+# Immunocapture
+# Note: this find only checks runs starting from 2020.  Silence stderr to avoid 'permission denied'.
+find /mnt/archgen/Autorun/Results/Human_IM/2* -name '*.bam' -mtime -1 2>/dev/null | cut -f 7 -d "/" | sort -u | while read RUN ; do
+    echo "Processing IM data from run: ${RUN}"
+    scripts/prepare_eager_tsv.R -s $RUN -a IM -o eager_inputs/ -d .eva_credentials
+done

--- a/scripts/ethical_sample_scrub.sh
+++ b/scripts/ethical_sample_scrub.sh
@@ -74,6 +74,8 @@ else
       eager_input_tsv="${root_input_dir}/${analysis_type}/${site_id}/${raw_iid}/${raw_iid}.tsv"
       ## If the eager inpput exists, hide the entire directory and make it inaccessible
       if [[ -f ${eager_input_tsv} ]]; then
+        errecho "Scrubbing ${raw_iid} from ${analysis_type}"
+        errecho "    ${raw_iid} ${eager_input_tsv}"
         old_name=$(dirname ${eager_input_tsv})
         new_name=$(dirname ${old_name})/.${raw_iid}
         mv -v ${old_name} ${new_name} ## Hide the input directory
@@ -83,6 +85,7 @@ else
       ## EAGER_OUTPUTS
       eager_output_dir="${root_output_dir}/${analysis_type}/${site_id}/${raw_iid}/"
       if [[ -d ${eager_output_dir} ]]; then
+        errecho "    ${rawiid} ${eager_output_dir}"
         new_outdir_name=$(dirname ${eager_output_dir})/.${raw_iid}
         mv -v ${eager_output_dir} ${new_outdir_name} ## Hide the output directory
         chmod 0700 ${new_outdir_name}                ## Restrict the directory contents

--- a/scripts/ethical_sample_scrub.sh
+++ b/scripts/ethical_sample_scrub.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+## DEPENDENCY
+pandora_helper="/mnt/archgen/tools/helper_scripts/py_helpers/pyPandoraHelper/pyPandoraHelper.py"
+
 ## Helptext function
 function Helptext() {
   echo -ne "\t usage: $0 [options] <sensitive_seqIds_list>\n\n"
@@ -65,7 +68,7 @@ else
   for raw_iid in ${scrub_me[@]}; do
     for analysis_type in "SG" "TF" "RP" "RM"; do
       ## EAGER_INPUTS
-      site_id="${raw_iid:0:3}"
+      site_id=`${pandora_helper} -g site_id ${ind_id}` ## Site inferred by pyPandoraHelper
       eager_input_tsv="${root_input_dir}/${analysis_type}/${site_id}/${raw_iid}/${raw_iid}.tsv"
       ## If the eager inpput exists, hide the entire directory and make it inaccessible
       if [[ -f ${eager_input_tsv} ]]; then

--- a/scripts/ethical_sample_scrub.sh
+++ b/scripts/ethical_sample_scrub.sh
@@ -3,6 +3,8 @@
 ## DEPENDENCY
 pandora_helper="/mnt/archgen/tools/helper_scripts/py_helpers/pyPandoraHelper/pyPandoraHelper.py"
 
+valid_analysis_types=("TF" "SG" "RP" "RM" "IM" "YC")
+
 ## Helptext function
 function Helptext() {
   echo -ne "\t usage: $0 [options] <sensitive_seqIds_list>\n\n"
@@ -66,7 +68,7 @@ else
 
   ## If the individuals were flagged as sensitive AFTER processing started, both the inputs and outputs should be made inaccessible.
   for raw_iid in ${scrub_me[@]}; do
-    for analysis_type in "SG" "TF" "RP" "RM"; do
+    for analysis_type in ${valid_analysis_types[@]}; do
       ## EAGER_INPUTS
       site_id=`${pandora_helper} -g site_id ${raw_iid}` ## Site inferred by pyPandoraHelper
       eager_input_tsv="${root_input_dir}/${analysis_type}/${site_id}/${raw_iid}/${raw_iid}.tsv"

--- a/scripts/ethical_sample_scrub.sh
+++ b/scripts/ethical_sample_scrub.sh
@@ -68,7 +68,7 @@ else
   for raw_iid in ${scrub_me[@]}; do
     for analysis_type in "SG" "TF" "RP" "RM"; do
       ## EAGER_INPUTS
-      site_id=`${pandora_helper} -g site_id ${ind_id}` ## Site inferred by pyPandoraHelper
+      site_id=`${pandora_helper} -g site_id ${raw_iid}` ## Site inferred by pyPandoraHelper
       eager_input_tsv="${root_input_dir}/${analysis_type}/${site_id}/${raw_iid}/${raw_iid}.tsv"
       ## If the eager inpput exists, hide the entire directory and make it inaccessible
       if [[ -f ${eager_input_tsv} ]]; then

--- a/scripts/prepare_eager_tsv.R
+++ b/scripts/prepare_eager_tsv.R
@@ -53,7 +53,7 @@ save_ind_tsv <- function(data, rename, output_dir, ...) {
   data %>% select(-individual.Full_Individual_Id) %>%  readr::write_tsv(file=paste0(ind_dir,"/",ind_id,".tsv")) ## Output structure can be changed here.
 
   ## Print Autorun_eager version to file
-  AE_version <- "1.6.0"
+  AE_version <- "1.6.1"
   cat(AE_version, file=paste0(ind_dir,"/autorun_eager_version.txt"), fill=T, append = F)
 }
 
@@ -139,7 +139,12 @@ complete_pandora_table <- join_pandora_tables(
   )
 ) %>% 
   convert_all_ids_to_values(., con = con) %>%
-  filter(sample.Ethically_culturally_sensitive == FALSE) ## Exclude ethically/culturally sensitive data. Conservative since it excludes NAs
+  filter(
+      ## Exclude ethically/culturally sensitive data. Conservative since it excludes NAs
+      sample.Ethically_culturally_sensitive == FALSE,
+      ## Exclude marked sequencing entities
+      sequencing.Exclude == FALSE
+    )
 
 tibble_input_iids <- complete_pandora_table %>% filter(sequencing.Run_Id == sequencing_batch_id) %>% select(individual.Full_Individual_Id) %>% distinct()
 

--- a/scripts/prepare_eager_tsv.R
+++ b/scripts/prepare_eager_tsv.R
@@ -12,6 +12,13 @@ if (!require('pandora2eager')) {
   remotes::install_github('sidora-tools/pandora2eager', quiet=T)
 } else {library(pandora2eager)}
 
+## Need rPandoraHelper
+if (!require('rPandoraHelper')) {
+    write("Installing required local package 'rPandoraHelper'...", file=stderr())
+    install.packages("/mnt/archgen/tools/helper_scripts/r_helpers/rPandoraHelper/", repos = NULL, type = "source")
+    # require(rPandoraHelper)
+} else {require(rPandoraHelper)}
+
 require(purrr)
 require(dplyr, warn.conflicts = F)
 require(optparse)
@@ -30,7 +37,7 @@ save_ind_tsv <- function(data, rename, output_dir, ...) {
 
   ## Infer Individual Id(s) from input.
   ind_id <- data %>% select(individual.Full_Individual_Id) %>% distinct() %>% pull()
-  site_id <- substr(ind_id,1,3)
+  site_id <- rPandoraHelper::get_site_id(ind_id)
 
   if (rename) {
     data <- data %>% mutate(Library_ID=str_replace_all(Library_ID, "[.]", "_")) %>% ## Replace dots in the Library_ID to underscores.

--- a/scripts/prepare_eager_tsv.R
+++ b/scripts/prepare_eager_tsv.R
@@ -53,7 +53,7 @@ save_ind_tsv <- function(data, rename, output_dir, ...) {
   data %>% select(-individual.Full_Individual_Id) %>%  readr::write_tsv(file=paste0(ind_dir,"/",ind_id,".tsv")) ## Output structure can be changed here.
 
   ## Print Autorun_eager version to file
-  AE_version <- "1.5.0"
+  AE_version <- "1.6.0"
   cat(AE_version, file=paste0(ind_dir,"/autorun_eager_version.txt"), fill=T, append = F)
 }
 

--- a/scripts/prepare_eager_tsv.R
+++ b/scripts/prepare_eager_tsv.R
@@ -61,10 +61,11 @@ save_ind_tsv <- function(data, rename, output_dir, ...) {
 ##    Only bams from the output autorun_name will be included in the output
 autorun_names_from_analysis_type <- function(analysis_type) {
   autorun_names <- case_when(
-    analysis_type == "TF" ~ c( "HUMAN_1240K", "Human_1240k" ),
+    analysis_type == "TF" ~ c( "HUMAN_1240K",   "Human_1240k" ),
     analysis_type == "SG" ~ c( "HUMAN_SHOTGUN", "Human_Shotgun" ),
-    analysis_type == "RP" ~ c( "HUMAN_RP", "Human_RP" ),
-    analysis_type == "RM" ~ c( "HUMAN_RM", "Human_RM" ),
+    analysis_type == "RP" ~ c( "HUMAN_RP",      "Human_RP" ),
+    analysis_type == "RM" ~ c( "HUMAN_RM",      "Human_RM" ),
+    analysis_type == "YC" ~ c( "HUMAN_Y",       "Human_Y" ),
     ## Future analyses can be added here to pull those bams for eager processsing.
     TRUE ~ NA_character_
   )

--- a/scripts/prepare_eager_tsv.R
+++ b/scripts/prepare_eager_tsv.R
@@ -146,7 +146,13 @@ complete_pandora_table <- join_pandora_tables(
       sequencing.Exclude == FALSE
     )
 
-tibble_input_iids <- complete_pandora_table %>% filter(sequencing.Run_Id == sequencing_batch_id) %>% select(individual.Full_Individual_Id) %>% distinct()
+## Any individuals with a Main_Individual_ID set in Pandora need to be included in the list of individuals to process.
+## First get the list of Full_Individual_IDs in the sequencing run
+fiid_list <- complete_pandora_table %>% filter(sequencing.Run_Id == sequencing_batch_id) %>% select(individual.Full_Individual_Id) %>% distinct()
+## Then get the list of non-missing Main_Individual_IDs in the sequencing run. Change the column name to match the Full_individual_Id column name.
+miid_list <- complete_pandora_table %>% filter(sequencing.Run_Id == sequencing_batch_id, individual.Main_Individual_Id != "") %>% select(individual.Full_Individual_Id=individual.Main_Individual_Id) %>% distinct()
+## Combine the two lists and remove duplicates
+tibble_input_iids <- bind_rows(fiid_list, miid_list) %>% distinct()
 
 ## Get protocol tab with udg and strandedness info for each library protocol
   pandora_library_protocol_info <- pandora2eager:::load_library_protocol_info(con)

--- a/scripts/prepare_eager_tsv.R
+++ b/scripts/prepare_eager_tsv.R
@@ -27,7 +27,7 @@ require(stringr)
 
 ## Validate analysis type option input
 validate_analysis_type <- function(option, opt_str, value, parser) {
-  valid_entries <- c("TF", "SG", "RP", "RM") ## TODO comment: should this be embedded within the function? You would want to maybe update this over time no? 
+  valid_entries <- c("TF", "SG", "RP", "RM", "YC") ## TODO comment: should this be embedded within the function? You would want to maybe update this over time no? 
   ifelse(value %in% valid_entries, return(value), stop(call.=F, "\n[prepare_eager_tsv.R] error: Invalid analysis type: '", value, 
                                                       "'\nAccepted values: ", paste(valid_entries,collapse=", "),"\n\n"))
 }
@@ -84,7 +84,7 @@ parser <- add_option(parser, c("-s", "--sequencing_batch_id"), type = 'character
 parser <- add_option(parser, c("-a", "--analysis_type"), type = 'character',
                     action = "callback", dest = "analysis_type",
                     callback = validate_analysis_type, default=NA,
-                    help = "The analysis type to compile the data from. Should be one of: 'SG', 'TF', 'RP', 'RM'.")
+                    help = "The analysis type to compile the data from. Should be one of: 'SG', 'TF', 'RP', 'RM', 'YC'.")
 parser <- add_option(parser, c("-r", "--rename"), type = 'logical',
                     action = 'store_true', dest = 'rename', default=F,
                     help = "Changes all dots (.) in the Library_ID field of the output to underscores (_).

--- a/scripts/prepare_eager_tsv.R
+++ b/scripts/prepare_eager_tsv.R
@@ -36,7 +36,7 @@ validate_analysis_type <- function(option, opt_str, value, parser) {
 save_ind_tsv <- function(data, rename, output_dir, ...) {
 
   ## Infer Individual Id(s) from input.
-  ind_id <- data %>% select(individual.Full_Individual_Id) %>% distinct() %>% pull()
+  ind_id <- data %>% select(target_ind) %>% distinct() %>% pull()
   site_id <- rPandoraHelper::get_site_id(ind_id)
 
   if (rename) {
@@ -50,7 +50,7 @@ save_ind_tsv <- function(data, rename, output_dir, ...) {
   if (!dir.exists(ind_dir)) {write(paste0("[prepare_eager_tsv.R]: Creating output directory '",ind_dir,"'"), stdout())}
   
   dir.create(ind_dir, showWarnings = F, recursive = T) ## Create output directory and subdirs if they do not exist.
-  data %>% select(-individual.Full_Individual_Id) %>%  readr::write_tsv(file=paste0(ind_dir,"/",ind_id,".tsv")) ## Output structure can be changed here.
+  data %>% ungroup() %>% select(-target_ind) %>%  readr::write_tsv(file=paste0(ind_dir,"/",ind_id,".tsv")) ## Output structure can be changed here.
 
   ## Print Autorun_eager version to file
   AE_version <- "1.6.1"
@@ -95,7 +95,9 @@ parser <- add_option(parser, c("-r", "--rename"), type = 'logical',
 parser <- add_option(parser, c("-w", "--whitelist"), type = 'character',
                     action = 'store', dest = 'whitelist_fn', default=NA_character_,
                     help = "An optional file that includes the IDs of whitelisted individuals,
-			one per line. Only the TSVs for these individuals will be updated."
+			one per line. Only the TSVs for these individuals will be updated.
+			Please note that the whitelist should contain the Main_Individual_ID of an individual,
+			not its Full_Individual_ID, if you want to include it in the output."
                     )
 parser <- add_option(parser, c("-o", "--outDir"), type = 'character',
                     action = "store", dest = "outdir",
@@ -155,14 +157,21 @@ miid_list <- complete_pandora_table %>% filter(sequencing.Run_Id == sequencing_b
 tibble_input_iids <- bind_rows(fiid_list, miid_list) %>% distinct()
 
 ## Get protocol tab with udg and strandedness info for each library protocol
-  pandora_library_protocol_info <- pandora2eager:::load_library_protocol_info(con)
+pandora_library_protocol_info <- pandora2eager:::load_library_protocol_info(con)
 
 ## Pull information from pandora, keeping only matching IIDs and requested Sequencing types.
 results <- inner_join(complete_pandora_table, tibble_input_iids, by=c("individual.Full_Individual_Id"="individual.Full_Individual_Id")) %>%
   filter(grepl(paste0("\\.", analysis_type), sequencing.Full_Sequencing_Id), analysis.Analysis_Id %in% autorun_names_from_analysis_type(analysis_type)) %>%
-  select(individual.Full_Individual_Id,individual.Organism,library.Full_Library_Id,library.Protocol,analysis.Result_Directory,sequencing.Sequencing_Id,sequencing.Full_Sequencing_Id,sequencing.Single_Stranded) %>%
+  select(individual.Full_Individual_Id,individual.Main_Individual_Id,individual.Organism,library.Full_Library_Id,library.Protocol,analysis.Result_Directory,sequencing.Sequencing_Id,sequencing.Full_Sequencing_Id,sequencing.Single_Stranded) %>%
   distinct() %>% ## Need distinct() call because of how analysis tab is read in, which created one copy of each row per analysis field.
-  group_by(individual.Full_Individual_Id) %>%
+  mutate(
+    target_ind = case_when(
+      individual.Main_Individual_Id == "" ~ individual.Full_Individual_Id,
+      TRUE ~ individual.Main_Individual_Id
+    )
+  ) %>%
+  ## Grouping by target_ind needed so the Lane counter restarts per target_ind.
+  group_by(target_ind) %>%
   filter(!is.na(analysis.Result_Directory)) %>% ## Exclude individuals with no results directory (seem to mostly be controls)
   mutate(
     ## Older entries have analysis directories pointing to projects1. These are in /mnt/archgen in EVA. 
@@ -187,17 +196,17 @@ results <- inner_join(complete_pandora_table, tibble_input_iids, by=c("individua
     R2=NA,
     ## Add `_ss` to sample name for ssDNA libraries. Avoids file name collisions and allows easier merging of genotypes for end users.
     Sample_Name = case_when(
-      sequencing.Single_Stranded == 'yes' ~ paste0(individual.Full_Individual_Id, "_ss"),
-      TRUE ~ individual.Full_Individual_Id
+      sequencing.Single_Stranded == 'yes' ~ paste0(target_ind, "_ss"),
+      TRUE ~ target_ind
     ),
     ## Also add the suffix to the Sample_ID part of the Library_ID. This ensures that in the MultiQC report, the ssDNA libraries will be sorted after the ssDNA sample.
     Library_ID = case_when(
-      sequencing.Single_Stranded == 'yes' ~ paste0(Sample_Name, ".", stringr::str_split_fixed(library.Full_Library_Id, "\\.", 2)[,2]),
+      sequencing.Single_Stranded == 'yes' ~ sub("\\.", "_ss.", library.Full_Library_Id),
       TRUE ~ library.Full_Library_Id
     )
   ) %>%
   select(
-    individual.Full_Individual_Id, ## Still used for grouping, so ss and ds results of the same sample end up in the same TSV.
+    target_ind, ## Still used for grouping, so ss and ds results of the same sample end up in the same TSV.
     "Sample_Name",
     "Library_ID",
     "Lane",
@@ -218,9 +227,9 @@ if ( opts$debug ) { write_tsv(results, file=paste0(sequencing_batch_id, ".", ana
 if (! is.na(whitelist_fn) ){
   whitelist <- read_tsv(whitelist_fn, col_types='c', col_names='Pandora_ID')
   
-  results <- results %>% filter(individual.Full_Individual_Id %in% whitelist$Pandora_ID)
+  results <- results %>% filter(target_ind %in% whitelist$Pandora_ID)
   # write_tsv(results, file=paste0(sequencing_batch_id, ".", analysis_type, ".whitelist.results.txt"))
 }
 
 ## Group by individual IDs and save each chunk as TSV
-results %>% group_by(individual.Full_Individual_Id) %>% group_walk(~save_ind_tsv(., rename=F, output_dir=output_dir), .keep=T)
+results %>% group_by(target_ind) %>% group_walk(~save_ind_tsv(., rename=F, output_dir=output_dir), .keep=T)

--- a/scripts/prepare_eager_tsv.R
+++ b/scripts/prepare_eager_tsv.R
@@ -27,7 +27,7 @@ require(stringr)
 
 ## Validate analysis type option input
 validate_analysis_type <- function(option, opt_str, value, parser) {
-  valid_entries <- c("TF", "SG", "RP", "RM", "YC") ## TODO comment: should this be embedded within the function? You would want to maybe update this over time no? 
+  valid_entries <- c("TF", "SG", "RP", "RM", "YC", "IM") ## TODO comment: should this be embedded within the function? You would want to maybe update this over time no? 
   ifelse(value %in% valid_entries, return(value), stop(call.=F, "\n[prepare_eager_tsv.R] error: Invalid analysis type: '", value, 
                                                       "'\nAccepted values: ", paste(valid_entries,collapse=", "),"\n\n"))
 }
@@ -66,6 +66,7 @@ autorun_names_from_analysis_type <- function(analysis_type) {
     analysis_type == "RP" ~ c( "HUMAN_RP",      "Human_RP" ),
     analysis_type == "RM" ~ c( "HUMAN_RM",      "Human_RM" ),
     analysis_type == "YC" ~ c( "HUMAN_Y",       "Human_Y" ),
+    analysis_type == "IM" ~ c( "HUMAN_IM",      "Human_IM" ),
     ## Future analyses can be added here to pull those bams for eager processsing.
     TRUE ~ NA_character_
   )
@@ -84,7 +85,7 @@ parser <- add_option(parser, c("-s", "--sequencing_batch_id"), type = 'character
 parser <- add_option(parser, c("-a", "--analysis_type"), type = 'character',
                     action = "callback", dest = "analysis_type",
                     callback = validate_analysis_type, default=NA,
-                    help = "The analysis type to compile the data from. Should be one of: 'SG', 'TF', 'RP', 'RM', 'YC'.")
+                    help = "The analysis type to compile the data from. Should be one of: 'SG', 'TF', 'RP', 'RM', 'YC', 'IM'.")
 parser <- add_option(parser, c("-r", "--rename"), type = 'logical',
                     action = 'store_true', dest = 'rename', default=F,
                     help = "Changes all dots (.) in the Library_ID field of the output to underscores (_).

--- a/scripts/run_Eager.sh
+++ b/scripts/run_Eager.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+## DEPENDENCY
+pandora_helper="/mnt/archgen/tools/helper_scripts/py_helpers/pyPandoraHelper/pyPandoraHelper.py"
+
 ## Defaults
 rush=''
 array=''
@@ -42,20 +45,10 @@ for analysis_type in "SG" "TF" "RP" "RM"; do
     for eager_input in ${root_input_dir}/${analysis_type}/*/*/*.tsv; do
         ## Set output directory name from eager input name
         ind_id=$(basename ${eager_input} .tsv)
-        site_id="${ind_id:0:3}"
+        site_id=`${pandora_helper} -g site_id ${ind_id}` ## Site inferred by pyPandoraHelper
         eager_output_dir="${root_output_dir}/${analysis_type}/${site_id}/${ind_id}"
 
         run_name="-resume" ## To be changed once/if a way to give informative run names becomes available
-        
-        ## TODO Give informative run names for easier trackingin tower.nf
-        ##  If the output directory exists, assume you need to resume a run, else just name it
-        # if [[ -d "${eager_output_dir}" ]]; then
-        #     command_string="-resume"
-        # else
-        #     command_string="-name"
-        # fi
-        # ## Run name is individual ID followed by analysis_type. -resume or -name added as appropriate
-        # run_name="${command_string} $(basename ${eager_input} .tsv)_${analysis_type}"
 
         ## If no multiqc_report exists (last step of eager), or TSV is newer than the report, start an eager run.
         #### Always running with resume will ensure runs are only ever resumed instead of restarting.

--- a/scripts/run_Eager.sh
+++ b/scripts/run_Eager.sh
@@ -4,6 +4,7 @@
 pandora_helper="/mnt/archgen/tools/helper_scripts/py_helpers/pyPandoraHelper/pyPandoraHelper.py"
 
 ## Defaults
+valid_analysis_types=("TF" "SG" "RP" "RM" "IM" "YC")
 rush=''
 array=''
 temp_file=''
@@ -38,7 +39,7 @@ Yellow=$(tput sgr0)'\033[1;33m' ## Yellow normal face
 
 ## Since I'm running through all data every time, the runtime of the script will increase marginally over time. 
 ## Maybe create a list of eager inputs that are newer than the MQC reports and use that to loop over?
-for analysis_type in "SG" "TF" "RP" "RM" "YC"; do
+for analysis_type in ${valid_analysis_types[@]}; do
     # echo ${analysis_type}
     analysis_profiles="${nextflow_profiles},${analysis_type}"
     # echo "${root_input_dir}/${analysis_type}"

--- a/scripts/run_Eager.sh
+++ b/scripts/run_Eager.sh
@@ -38,7 +38,7 @@ Yellow=$(tput sgr0)'\033[1;33m' ## Yellow normal face
 
 ## Since I'm running through all data every time, the runtime of the script will increase marginally over time. 
 ## Maybe create a list of eager inputs that are newer than the MQC reports and use that to loop over?
-for analysis_type in "SG" "TF" "RP" "RM"; do
+for analysis_type in "SG" "TF" "RP" "RM" "YC"; do
     # echo ${analysis_type}
     analysis_profiles="${nextflow_profiles},${analysis_type}"
     # echo "${root_input_dir}/${analysis_type}"

--- a/scripts/run_Eager.sh
+++ b/scripts/run_Eager.sh
@@ -113,7 +113,7 @@ if [[ ${array} == 'TRUE' ]]; then
     mkdir -p array_Logs/$(basename ${temp_file}) ## Create new directory for the logs for more traversable structure
     jn=$(wc -l ${temp_file} | cut -f 1 -d " ") ## number of jobs equals number of lines
     export NXF_OPTS='-Xms4G -Xmx4G' ## Set 4GB limit to Nextflow VM
-    export JAVA_OPTS='-Xms8G -Xmx8G' ## Set 8GB limit to Java VM
+    export JAVA_OPTS='-Xms8G -Xmx8G -XX:ParallelGCThreads=1' ## Set 8GB limit to Java VM. Single GarbageCollecteor thread
     ## -V Pass environment to job (includes nxf/java opts)
     ## -S /bin/bash Use bash
     ## -l v_hmem=40G ## 40GB memory limit (8 for java + the rest for garbage collector)

--- a/scripts/update_poseidon_package.sh
+++ b/scripts/update_poseidon_package.sh
@@ -2,6 +2,9 @@
 
 VERSION="1.5.0"
 
+## DEPENDENCY
+pandora_helper="/mnt/archgen/tools/helper_scripts/py_helpers/pyPandoraHelper/pyPandoraHelper.py"
+
 ## Colours for printing to terminal
 Yellow=$(tput sgr0)'\033[1;33m' ## Yellow normal face
 Red=$(tput sgr0)'\033[1;31m' ## Red normal face
@@ -41,11 +44,14 @@ while true ; do
   esac
 done
 
+site_id=`${pandora_helper} -g site_id ${ind_id}` ## Site inferred by pyPandoraHelper
+
 autorun_root_dir='/mnt/archgen/Autorun_eager/'
 root_input_dir='/mnt/archgen/Autorun_eager/eager_outputs' ## Directory should include subdirectories for each analysis type (TF/SG) and sub-subdirectories for each site and individual.
-root_output_dir='/mnt/archgen/Autorun_eager/dev/poseidon_packages' ## Directory that includes data type, site ID and ind ID subdirs.
-input_dir="${root_input_dir}/TF/${ind_id:0:3}/${ind_id}/genotyping/"
-output_dir="${root_output_dir}/TF/${ind_id:0:3}/${ind_id}/"
+root_output_dir='/mnt/archgen/Autorun_eager/poseidon_packages' ## Directory that includes data type, site ID and ind ID subdirs.
+# root_output_dir='/mnt/archgen/Autorun_eager/dev/poseidon_packages' ## dev directory for testing the creation of poseidon packages.
+input_dir="${root_input_dir}/TF/${site_id}/${ind_id}/genotyping/"
+output_dir="${root_output_dir}/TF/${site_id}/${ind_id}/"
 cred_file="${autorun_root_dir}/.eva_credentials"
 trident_path="/r1/people/srv_autoeager/bin/trident-1.1.4.2"
 
@@ -53,8 +59,8 @@ trident_path="/r1/people/srv_autoeager/bin/trident-1.1.4.2"
 # autorun_root_dir='/Users/lamnidis/Software/github/MPI-EVA-Archaeogenetics/Autorun_eager'
 # root_input_dir='/Users/lamnidis/mount/eager_outputs' ## Directory should include subdirectories for each analysis type (TF/SG) and sub-subdirectories for each site and individual.
 # root_output_dir='/Users/lamnidis/Software/github/MPI-EVA-Archaeogenetics/Autorun_eager/test_data/' ## Directory that includes data type, site ID and ind ID subdirs.
-# input_dir="${root_input_dir}/TF/${ind_id:0:3}/${ind_id}/genotyping/"
-# output_dir="${root_output_dir}/TF/${ind_id:0:3}/${ind_id}/"
+# input_dir="${root_input_dir}/TF/${site_id}/${ind_id}/genotyping/"
+# output_dir="${root_output_dir}/TF/${site_id}/${ind_id}/"
 # cred_file="/Users/lamnidis/Software/github/Schiffels-Popgen/MICROSCOPE-processing-pipeline/.credentials"
 # trident_path=$(which trident)
 

--- a/scripts/update_poseidon_package.sh
+++ b/scripts/update_poseidon_package.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-VERSION="1.5.0"
+VERSION="1.6.0"
 
 ## DEPENDENCY
 pandora_helper="/mnt/archgen/tools/helper_scripts/py_helpers/pyPandoraHelper/pyPandoraHelper.py"


### PR DESCRIPTION
- [x] `conf/Autorun.config`: Use hard links when publishing results, instead of copying files.
- [x] `scripts/create_poseidon_release.sh`: New script to create large releases of the entire TF processed data in Poseidon format.
- The following scripts now use pyPandoraHelper to infer Site_ID from Ind_ID:
  - `scripts/clear_results.sh`
  - `scripts/clear_work_dirs.sh`
  - `scripts/ethical_sample_scrub.sh`
  - `scripts/run_Eager.sh`
  - `scripts/update_poseidon_packages.sh`
- [x] TODO: The R scripts have been updated to allow variable length Site_IDs.
- [x] TODO: The pipeline has been extended to process YC data.
- [x] TODO: The pipeline has been extended to process IM data.

## PR checklist

 - [x] This comment contains a description of changes (with reason).
 - [x] Bump version number within `prepare_eager_tsv.R`.
 - [x] Bump version number in `update_poseidon_package.sh`.
 - [x] `CHANGELOG.md` is updated.
 - [ ] `README.md` is updated (including new tool citations and authors/contributors).